### PR TITLE
Allow dynamic values in v-link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ p.start = function (vm) {
     return
   }
   this._started = true
-  this._vm = this._vm || vm
+  this._vm = this._vm || vm.$root
   if (!this._vm) {
     throw new Error(
       'vue-router must be started with a root Vue instance.'

--- a/src/link.js
+++ b/src/link.js
@@ -6,20 +6,23 @@ module.exports = function (Vue) {
   Vue.directive('link', {
 
     bind: function () {
-      var vm = this.vm
-      var href = this.expression
-      if (this.el.tagName === 'A') {
-        this.el.href = href
-      }
+      var self = this
       this.handler = function (e) {
         e.preventDefault()
-        vm.route._router.go(href)
+        self.vm.$root.route._router.go(self.destination)
       }
       this.el.addEventListener('click', this.handler)
     },
 
     unbind: function () {
       this.el.removeEventListener('click', this.handler)
+    },
+
+    update: function (value) {
+      this.destination = value
+      if (this.el.tagName === 'A') {
+        this.el.href = value
+      }
     }
 
   })


### PR DESCRIPTION
There's a pretty significant change here in storing the router instance to the `vm.$root` rather than just the `vm`.

I found that navigating with `v-link` in a deeply nested component couldn't find the `_router` instance:
> Uncaught TypeError: Cannot read property '_router' of undefined

By mounting to the root VM and referencing it later, I was able to resolve this issue - but I'm not sure it's the best solution.

Closes https://github.com/vuejs/vue-router/issues/3