### PR TITLE
Follow v-link with left button only to allow opening in a new tab by middle clicking

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -20,11 +20,10 @@ module.exports = function (Vue) {
       }
       var self = this
       this.handler = function (e) {
-        if (e.button !== 0) {
-          return 
+        if (e.button === 0) {
+          e.preventDefault()
+          vm.route._router.go(self.destination)
         }
-        e.preventDefault()
-        vm.route._router.go(self.destination)
       }
       this.el.addEventListener('click', this.handler)
       if (!this._isDynamicLiteral) {

--- a/src/link.js
+++ b/src/link.js
@@ -20,6 +20,9 @@ module.exports = function (Vue) {
       }
       var self = this
       this.handler = function (e) {
+        if (e.button !== 0) {
+          return 
+        }
         e.preventDefault()
         vm.route._router.go(self.destination)
       }


### PR DESCRIPTION
Links using `v-link` don't react properly to middle clicking (i.e.: open in a new tab). Links should only navigate to destination if left-clicked.