### PR TITLE
plugin auto installation with Vue.use()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ Router.install = function (Vue) {
 // auto install
 /* istanbul ignore if */
 if (typeof window !== 'undefined' && window.Vue) {
-  Router.install(window.Vue)
+  window.Vue.use(Router)
 }
 
 module.exports = Router


### PR DESCRIPTION
The `vue-router` plugin auto installation works, but
I think that `vie-router` plugin should use` Vue.use` to keep consistency of plugin installation.