### PR TITLE
Use environment variable for sauce username setting instead of 'vuejs'

### DIFF
--- a/build/nightwatch.sauce.json
+++ b/build/nightwatch.sauce.json
@@ -5,7 +5,7 @@
     "default" : {
       "selenium_port": 80,
       "selenium_host": "ondemand.saucelabs.com",
-      "username": "vuejs",
+      "username": "${SAUCE_USERNAME}",
       "access_key": "${SAUCE_ACCESS_KEY}",
       "silent": true
     },


### PR DESCRIPTION
I was just trying to run test via saucelab.com and ran into the problem that username and access_key doesn't match.
Turns out in the `build/nightwatch.sauce.json`, `username` is set to `vuejs` manually.
So I change it to `${SAUCE_USERNAME}` just like the variable in the `circle.yml`.
And everything works!