### PR TITLE
Replace requires with import statements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 import { warn } from './util'
 import Router from './router'
 
+import RouterApi from './router/api'
+import RouterInternal from './router/internal'
+import View from './directives/view'
+import Link from './directives/link'
+import Override from './override'
+
 /**
  * Installation interface.
  * Install the necessary directives.
@@ -12,11 +18,11 @@ Router.install = function (Vue) {
     warn('already installed.')
     return
   }
-  require('./router/api')(Vue, Router)
-  require('./router/internal')(Vue, Router)
-  require('./directives/view')(Vue)
-  require('./directives/link')(Vue)
-  require('./override')(Vue)
+  RouterApi(Vue, Router)
+  RouterInternal(Vue, Router)
+  View(Vue)
+  Link(Vue)
+  Override(Vue)
   Router.Vue = Vue
   Router.installed = true
 }

--- a/src/router.js
+++ b/src/router.js
@@ -16,7 +16,7 @@ const historyBackends = {
  * @param {Object} [options]
  */
 
-export default class Router {
+class Router {
 
   constructor ({
     hashbang = true,
@@ -96,3 +96,5 @@ export default class Router {
 }
 
 Router.installed = false
+
+export default Router

--- a/src/router.js
+++ b/src/router.js
@@ -1,9 +1,13 @@
 import Recognizer from 'route-recognizer'
 
+import abstract from './history/abstract'
+import hash from './history/hash'
+import html5 from './history/html5'
+
 const historyBackends = {
-  abstract: require('../history/abstract'),
-  hash: require('../history/hash'),
-  html5: require('../history/html5')
+  abstract: abstract,
+  hash: hash,
+  html5: html5
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,4 @@
+import Router from './router'
 import RouteRecognizer from 'route-recognizer'
 const genQuery = RouteRecognizer.prototype.generateQueryString
 
@@ -102,7 +103,7 @@ export function resolveAsyncComponent (handler, cb) {
   if (!resolver) {
     resolver = {
       // HACK
-      resolve: require('./router').Vue.prototype._resolveComponent,
+      resolve: Router.Vue.prototype._resolveComponent,
       $options: {
         components: {
           _: handler.component


### PR DESCRIPTION
- replace `require`s with `import`s
- Moved router/index.js to router.js as `import router` does not play well with non-node environments (or maybe babel allows for package index imports?)