### PR TITLE
Distribute source with package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.6.2",
   "description": "A router for Vue.js",
   "main": "lib/index.js",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "dev": "npm run serve & npm run serve-test",
     "lint": "eslint src build test/e2e test/unit/specs",


### PR DESCRIPTION
From the comments on #103 
> In order to import src/index.js, should "files": ["src"] be added to the package.json?
