### PR TITLE
Throw exception when router started w/ Vue instance

### DIFF
--- a/docs/en/api/start.md
+++ b/docs/en/api/start.md
@@ -8,6 +8,9 @@ Start the router-enabled app. Creates an instance of `App` and mounts it to `el`
 
   The `App` can be a Vue component constructor or a component options object. If it's an object, the router will implicitly call `Vue.extend` on it. This component will be used to create the root Vue instance for the app.
 
+  **Note:**
+  vue-router cannot be started with Vue instances.
+
 - `el: String|Element`
 
   The element to mount the app on. Can be a CSS selector string or an actual element.

--- a/docs/en/basic.md
+++ b/docs/en/basic.md
@@ -32,6 +32,7 @@ var Bar = Vue.extend({
 // The router needs a root component to render.
 // For demo purposes, we will just use an empty one
 // because we are using the HTML as the app template.
+// !! Note that the App is not a Vue instance.
 var App = Vue.extend({})
 
 // Create a router instance.

--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,12 @@ class Router {
           'root container.'
         )
       }
+      if (App instanceof Vue) {
+        throw new Error(
+          'Must start vue-router with a component, not a ' +
+          'Vue instance.'
+        )
+      }
       this._appContainer = container
       const Ctor = this._appConstructor = typeof App === 'function'
         ? App


### PR DESCRIPTION
It seems like passing a Vue instance to the router instead of a component constructor is a somewhat common and easy mistake to make. See #260 and vuejs/vue#1981.