### PR TITLE
fix a bug , in histroy mode, no same origin link be a path

### DIFF
--- a/src/directives/link.js
+++ b/src/directives/link.js
@@ -48,7 +48,9 @@ export default function (Vue) {
 
         if (this.el.tagName === 'A' || e.target === this.el) {
           // v-link on <a v-link="'path'">
-          go(target)
+          if (sameOrigin(el)) {
+            go(target)
+          }
         } else {
           // v-link delegate on <div v-link>
           var el = e.target


### PR DESCRIPTION
histroy 模式下，非同源链接无法正常跳转

`<a v-link="'http://baidu.com'">Baidu</a>`

将会进入 http://localhost:2000/http://baidu.com 