### PR TITLE
Emit route-data-loaded event for <router-view>

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -289,10 +289,12 @@ function loadData (component, transition, hook, cb, cleanup) {
     }
     if (!promises.length) {
       component.$loadingRouteData = false
+      component.$emit('route-data-loaded', component)
       cb && cb()
     } else {
       promises[0].constructor.all(promises).then(_ => {
         component.$loadingRouteData = false
+        component.$emit('route-data-loaded', component)
         cb && cb()
       }, onError)
     }


### PR DESCRIPTION
With this patch, we can listen routeDataLoaded event on `<router-view>`.

```html
<router-view @route-data-loaded="doSomething"></router-view>
```

In this doSomething:

1. we can send collect analytics data
2. we can change document.title
3. and many other things

https://github.com/vuejs/vue-router/issues/112