### PR TITLE
Vue.prototype._init override should accept no args

### DIFF
--- a/src/override.js
+++ b/src/override.js
@@ -5,6 +5,7 @@ export default function (Vue) {
   // override Vue's init and destroy process to keep track of router instances
   const init = Vue.prototype._init
   Vue.prototype._init = function (options) {
+    options = options || {}
     const root = options._parent || options.parent || this
     const route = root.$route
     if (route) {

--- a/test/unit/specs/core.js
+++ b/test/unit/specs/core.js
@@ -11,6 +11,12 @@ describe('Core', function () {
     spyOn(window, 'scrollTo')
   })
 
+  it('call Vue constructor with no arguments', function () {
+    /* eslint-disable no-new */
+    new Vue()
+    /* eslint-enable no-new */
+  })
+
   it('matching views', function (done) {
     router = new Router({ abstract: true })
     router.map({


### PR DESCRIPTION
After installing the vue-router plugin, it overrides `Vue.prototype._init` but doesn't coalesce the options argument like the original `Vue.prototype._init` function does. Sometimes Vue constructor functions get passed around in my app and I would like to instantiate an instance of a particular component by just newing it up with out any args.