### PR TITLE
Fix v-link href value

### DIFF
--- a/src/directives/link.js
+++ b/src/directives/link.js
@@ -128,10 +128,6 @@ export default function (Vue) {
       if (this.el.tagName !== 'A') {
         return
       }
-      if (this.target && this.target.name) {
-        this.el.href = '#' + this.target.name
-        return
-      }
       const path = this.path
       const router = this.router
       const isAbsolute = path.charAt(0) === '/'


### PR DESCRIPTION
The href value is correct before this release. Every named route is
`#{name}` now. Remove this useless code.