### PR TITLE
fix history.replaceState() with base and null url

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -48,7 +48,7 @@ export default class HTML5History {
           x: window.pageXOffset,
           y: window.pageYOffset
         }
-      }, '')
+      }, '', location.href)
       // then push new state
       history.pushState({}, '', url)
     }


### PR DESCRIPTION
According to the standard, if the URL parameter is omitted (or `null`) from the `history.replaceState()` call, the new URL should be the URL of the current entry. In Safari, however, *when a `<base>` tag is present*, if you omit the URL parameter, then Safari will assign the URL of the current entry to the base tag's href. This essentially breaks HTML5 history completely for Safari.

The bug I'm referring to seems to be exactly [this one](https://code.google.com/p/chromium/issues/detail?id=279278) (but for Safari not Chrome).

I'm using the latest version of Safari (9.0.3).

I would've written a test for this, but you haven't configured a Safari Selenium driver (it's an OSX thing, so I dunno if that's able to be tested as part of your CI setup).