### PR TITLE
修改router.start以便与vue cli webpack boilerplate进行整合

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ class Router {
    * @param {Function} [cb]
    */
 
-  start (App, container, cb) {
+  start (App, container, replace, cb) {
     /* istanbul ignore if */
     if (this._started) {
       warn('already started.')
@@ -257,7 +257,10 @@ class Router {
           'Vue instance.'
         )
       }
-      this._appContainer = container
+      this._appContainer = {
+        el: container,
+        replace: replace === undefined ? true : !!replace
+      }
       const Ctor = this._appConstructor = typeof App === 'function'
         ? App
         : Vue.extend(App)
@@ -463,7 +466,8 @@ class Router {
       // initial render
       const router = this
       this.app = new this._appConstructor({
-        el: this._appContainer,
+        el: this._appContainer.el,
+        replace: this._appContainer.replace,
         created () {
           this.$router = router
         },


### PR DESCRIPTION
你好！我在将webpack boilerplate与vue router整合时碰到了问题，如果代码这样写的话
```
router.start(App, 'body')
```
vue router会将body节点替换成div；所以是否可以考虑接受这样的修改？