### PR TITLE
Add a handleClick method for rewriting purpose.

### DIFF
--- a/src/directives/link.js
+++ b/src/directives/link.js
@@ -82,7 +82,7 @@ export default function (Vue) {
       if (target) {
         // v-link with expression, just go
         e.preventDefault()
-        this.router.go(target)
+        this.handleClick(target, this.el)
       } else {
         // no expression, delegate for an <a> inside
         var el = e.target
@@ -91,13 +91,17 @@ export default function (Vue) {
         }
         if (el.tagName === 'A' && sameOrigin(el)) {
           e.preventDefault()
-          this.router.go({
+          this.handleClick({
             path: el.pathname,
             replace: target && target.replace,
             append: target && target.append
-          })
+          }, el)
         }
       }
+    },
+
+    handleClick (target, el) {
+      this.router.go(target)
     },
 
     onRouteUpdate (route) {


### PR DESCRIPTION
The `handleClick` accepts an extra `el` parameter, which is used for rewriting the method.

Now, I rewrite the whole `onClick` for `v-link` in my case.

1. A `<a>` has title information
2. Click on `<a>` link, get title information from `<a>` element
3. Set `document.title` with this `<a>` element title information

It is not limited with `document.title`. For a hybrid Application, it is quite useful
to send the title information of the next page to the App container.