### PR TITLE
Fixed the query encoding order issue.

### DIFF
--- a/docs/en/pipeline/data.md
+++ b/docs/en/pipeline/data.md
@@ -108,7 +108,7 @@ Using `$loadingRouteData` in templates:
   <div v-if="$loadingRouteData">Loading ...</div>
   <div v-if="!$loadingRouteData">
     <user-profile user="{{user}}"></user-profile>
-    <user-post v-repeat="post in posts"></user-post>
+    <user-post v-for="post in posts"></user-post>
   </div>
 </div>
 ```

--- a/docs/ja/pipeline/data.md
+++ b/docs/ja/pipeline/data.md
@@ -107,7 +107,7 @@ route: {
   <div v-if="$loadingRouteData">Loading ...</div>
   <div v-if="!$loadingRouteData">
     <user-profile user="{{user}}"></user-profile>
-    <user-post v-repeat="post in posts"></user-post>
+    <user-post v-for="post in posts"></user-post>
   </div>
 </div>
 ```

--- a/docs/zh-cn/pipeline/data.md
+++ b/docs/zh-cn/pipeline/data.md
@@ -106,7 +106,7 @@ route: {
   <div v-if="$loadingRouteData">Loading ...</div>
   <div v-if="!$loadingRouteData">
     <user-profile user="{{user}}"></user-profile>
-    <user-post v-repeat="post in posts"></user-post>
+    <user-post v-for="post in posts"></user-post>
   </div>
 </div>
 ```

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -490,14 +490,14 @@ RouteRecognizer.prototype = {
         pathLen, i, l, queryStart, queryParams = {},
         isSlashDropped = false;
 
+    path = decodeURI(path);
+
     queryStart = path.indexOf('?');
     if (queryStart !== -1) {
       var queryString = path.substr(queryStart + 1, path.length);
       path = path.substr(0, queryStart);
       queryParams = this.parseQueryString(queryString);
     }
-
-    path = decodeURI(path);
 
     // DEBUG GROUP path
 

--- a/src/directives/link.js
+++ b/src/directives/link.js
@@ -101,9 +101,9 @@ export default function (Vue) {
     },
 
     onRouteUpdate (route) {
-      // router._stringifyPath is dependent on current route
+      // router.stringifyPath is dependent on current route
       // and needs to be called again whenver route changes.
-      var newPath = this.router._stringifyPath(this.target)
+      var newPath = this.router.stringifyPath(this.target)
       if (this.path !== newPath) {
         this.path = newPath
         this.updateActiveMatch()

--- a/src/directives/link.js
+++ b/src/directives/link.js
@@ -91,8 +91,12 @@ export default function (Vue) {
         }
         if (el.tagName === 'A' && sameOrigin(el)) {
           e.preventDefault()
+          var path = el.pathname
+          if (this.router.history.root) {
+            path = path.replace(this.router.history.rootRE, '')
+          }
           this.router.go({
-            path: el.pathname,
+            path: path,
             replace: target && target.replace,
             append: target && target.append
           })

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -4,7 +4,7 @@ const hashRE = /#.*$/
 export default class HTML5History {
 
   constructor ({ root, onChange }) {
-    if (root) {
+    if (root && root !== '/') {
       // make sure there's the starting slash
       if (root.charAt(0) !== '/') {
         root = '/' + root

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ class Router {
       replace = path.replace
       append = path.append
     }
-    path = this._stringifyPath(path)
+    path = this.stringifyPath(path)
     if (path) {
       this.history.go(path, replace, append)
     }
@@ -293,6 +293,47 @@ class Router {
   stop () {
     this.history.stop()
     this._started = false
+  }
+
+  /**
+   * Normalize named route object / string paths into
+   * a string.
+   *
+   * @param {Object|String|Number} path
+   * @return {String}
+   */
+
+  stringifyPath (path) {
+    let fullPath = ''
+    if (path && typeof path === 'object') {
+      if (path.name) {
+        const extend = Vue.util.extend
+        const currentParams =
+          this._currentTransition &&
+          this._currentTransition.to.params
+        const targetParams = path.params || {}
+        const params = currentParams
+          ? extend(extend({}, currentParams), targetParams)
+          : targetParams
+        if (path.query) {
+          params.queryParams = path.query
+        }
+        fullPath = encodeURI(this._recognizer.generate(path.name, params))
+      } else if (path.path) {
+        fullPath = encodeURI(path.path)
+        if (path.query) {
+          const query = this._recognizer.generateQueryString(path.query)
+          if (fullPath.indexOf('?') > -1) {
+            fullPath += '&' + query.slice(1)
+          } else {
+            fullPath += query
+          }
+        }
+      }
+    } else {
+      fullPath = encodeURI(path ? path + '' : '')
+    }
+    return fullPath
   }
 
   // Internal methods ======================================
@@ -557,47 +598,6 @@ class Router {
         }
       })
     }
-  }
-
-  /**
-   * Normalize named route object / string paths into
-   * a string.
-   *
-   * @param {Object|String|Number} path
-   * @return {String}
-   */
-
-  _stringifyPath (path) {
-    let fullPath = ''
-    if (path && typeof path === 'object') {
-      if (path.name) {
-        const extend = Vue.util.extend
-        const currentParams =
-          this._currentTransition &&
-          this._currentTransition.to.params
-        const targetParams = path.params || {}
-        const params = currentParams
-          ? extend(extend({}, currentParams), targetParams)
-          : targetParams
-        if (path.query) {
-          params.queryParams = path.query
-        }
-        fullPath = encodeURI(this._recognizer.generate(path.name, params))
-      } else if (path.path) {
-        fullPath = encodeURI(path.path)
-        if (path.query) {
-          const query = this._recognizer.generateQueryString(path.query)
-          if (fullPath.indexOf('?') > -1) {
-            fullPath += '&' + query.slice(1)
-          } else {
-            fullPath += query
-          }
-        }
-      }
-    } else {
-      fullPath = encodeURI(path ? path + '' : '')
-    }
-    return fullPath
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -599,6 +599,25 @@ class Router {
       })
     }
   }
+        }
+        fullPath = encodeURI(this._recognizer.generate(path.name, params))
+      } else if (path.path) {
+        fullPath = path.path
+        if (path.query) {
+          const query = this._recognizer.generateQueryString(path.query)
+          if (fullPath.indexOf('?') > -1) {
+            fullPath += '&' + query.slice(1)
+          } else {
+            fullPath += query
+          }
+        }
+        fullPath = encodeURI(fullPath)
+      }
+    } else {
+      fullPath = encodeURI(path ? path + '' : '')
+    }
+    return fullPath
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -320,7 +320,7 @@ class Router {
         }
         fullPath = encodeURI(this._recognizer.generate(path.name, params))
       } else if (path.path) {
-        fullPath = encodeURI(path.path)
+        fullPath = path.path
         if (path.query) {
           const query = this._recognizer.generateQueryString(path.query)
           if (fullPath.indexOf('?') > -1) {
@@ -329,6 +329,7 @@ class Router {
             fullPath += query
           }
         }
+        fullPath = encodeURI(fullPath)
       }
     } else {
       fullPath = encodeURI(path ? path + '' : '')
@@ -598,25 +599,6 @@ class Router {
         }
       })
     }
-  }
-        }
-        fullPath = encodeURI(this._recognizer.generate(path.name, params))
-      } else if (path.path) {
-        fullPath = path.path
-        if (path.query) {
-          const query = this._recognizer.generateQueryString(path.query)
-          if (fullPath.indexOf('?') > -1) {
-            fullPath += '&' + query.slice(1)
-          } else {
-            fullPath += query
-          }
-        }
-        fullPath = encodeURI(fullPath)
-      }
-    } else {
-      fullPath = encodeURI(path ? path + '' : '')
-    }
-    return fullPath
   }
 }
 

--- a/test/unit/specs/core.js
+++ b/test/unit/specs/core.js
@@ -1117,14 +1117,14 @@ describe('Stringify Path', function () {
   })
 
   it('plain string', function () {
-    expect(router._stringifyPath('a')).toBe('a')
+    expect(router.stringifyPath('a')).toBe('a')
   })
 
   it('object path', function () {
-    expect(router._stringifyPath({ path: '/hi' })).toBe('/hi')
-    expect(router._stringifyPath({ path: '/hi', query: { a: 1 } })).toBe('/hi?a=1')
-    expect(router._stringifyPath({ path: '/hi', query: { a: 1, b: 2 } })).toBe('/hi?a=1&b=2')
-    expect(router._stringifyPath({ path: '/hi?c=3', query: { a: 1, b: 2 } })).toBe('/hi?c=3&a=1&b=2')
+    expect(router.stringifyPath({ path: '/hi' })).toBe('/hi')
+    expect(router.stringifyPath({ path: '/hi', query: { a: 1 } })).toBe('/hi?a=1')
+    expect(router.stringifyPath({ path: '/hi', query: { a: 1, b: 2 } })).toBe('/hi?a=1&b=2')
+    expect(router.stringifyPath({ path: '/hi?c=3', query: { a: 1, b: 2 } })).toBe('/hi?c=3&a=1&b=2')
   })
 
   it('named route', function () {
@@ -1134,14 +1134,14 @@ describe('Stringify Path', function () {
         component: {}
       }
     })
-    expect(router._stringifyPath({ name: 'a' })).toBe('/test/:id')
-    expect(router._stringifyPath({ name: 'a', params: { id: 0 } })).toBe('/test/0')
-    expect(router._stringifyPath({ name: 'a', params: { id: 'hi' } })).toBe('/test/hi')
+    expect(router.stringifyPath({ name: 'a' })).toBe('/test/:id')
+    expect(router.stringifyPath({ name: 'a', params: { id: 0 } })).toBe('/test/0')
+    expect(router.stringifyPath({ name: 'a', params: { id: 'hi' } })).toBe('/test/hi')
   })
 
   it('named route not found should throw error', function () {
     expect(function () {
-      router._stringifyPath({
+      router.stringifyPath({
         name: 'a'
       })
     }).toThrow()
@@ -1154,9 +1154,9 @@ describe('Stringify Path', function () {
         component: {}
       }
     })
-    expect(router._stringifyPath('/hi/你好')).toBe(encodeURI('/hi/你好'))
-    expect(router._stringifyPath({ path: '/hi/你好' })).toBe(encodeURI('/hi/你好'))
-    expect(router._stringifyPath({ name: 'a', params: { id: '你好' }})).toBe(encodeURI('/test/你好'))
+    expect(router.stringifyPath('/hi/你好')).toBe(encodeURI('/hi/你好'))
+    expect(router.stringifyPath({ path: '/hi/你好' })).toBe(encodeURI('/hi/你好'))
+    expect(router.stringifyPath({ name: 'a', params: { id: '你好' }})).toBe(encodeURI('/test/你好'))
   })
 
 })

--- a/test/unit/specs/core.js
+++ b/test/unit/specs/core.js
@@ -100,7 +100,7 @@ describe('Core', function () {
     router = new Router({ abstract: true })
     router.map({
       '/a': {
-        component: { template: 'A{{$route.qyery.msg}}' }
+        component: { template: 'A{{$route.query.msg}}' }
       },
       '/b': {
         name: 'b',

--- a/test/unit/specs/core.js
+++ b/test/unit/specs/core.js
@@ -96,6 +96,36 @@ describe('Core', function () {
     ], done)
   })
 
+  it('go () querystring coding', function (done) {
+    router = new Router({ abstract: true })
+    router.map({
+      '/a': {
+        component: { template: 'A{{$route.qyery.msg}}' }
+      },
+      '/b': {
+        name: 'b',
+        component: { template: 'B{{$route.query.msg}}' }
+      },
+      '/c': {
+        component: { template: 'C{{$route.query.msg}}' }
+      }
+    })
+    var App = Vue.extend({
+      replace: false,
+      template: '<router-view></router-view>'
+    })
+    var query = {msg: 'https://www.google.com/#q=vuejs'}
+    router.start(App, el)
+    assertRoutes([
+      // object with path
+      [{ path: '/a', query: query }, 'A' + query.msg],
+      // object with named route
+      [{ name: 'b', query: query }, 'B' + query.msg],
+      // string path
+      ['/c?msg=' + encodeURIComponent(query.msg), 'C' + query.msg]
+    ], done)
+  })
+
   it('matching nested views', function (done) {
     router = new Router({ abstract: true })
     router.map({


### PR DESCRIPTION
The original code would encode full path differently based on whether the path was supplied as `name` or as `path`. Fixed so that all branches conform to the same encoding order, which is encoding of URI components and then or URI itself. Also, route-recognizer would decode in inverse order (first decode URI components and then URI). That was fixed as well (encode and decode orders should be inverse).

This should address issue https://github.com/vuejs/vue-router/issues/378 and fix an issue introduced by https://github.com/vuejs/vue-router/pull/391 PR.
