### PR TITLE
Avoid an error when a root '/' for VueRouter is specified (fix #379)

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -4,7 +4,7 @@ const hashRE = /#.*$/
 export default class HTML5History {
 
   constructor ({ root, onChange }) {
-    if (root) {
+    if (root && root !== '/') {
       // make sure there's the starting slash
       if (root.charAt(0) !== '/') {
         root = '/' + root


### PR DESCRIPTION
This is reported in https://github.com/vuejs/vue-router/issues/379
The reproduce step is just specifying '/' as root like below.

```js
const router = new VueRouter({
  history: true,
  saveScrollPosition: true,
  root: '/'
})
```
You can see `"Invalid regular expression: /^\/: \ at end of pattern"`.

The root param '/' is not needed and we can just remove it to work as expected, but I think it's better to avoid a runtime error when it's explicitly specified.