### PR TITLE
lower v-link priority #390

### DIFF
--- a/src/directives/link.js
+++ b/src/directives/link.js
@@ -15,14 +15,14 @@ export default function (Vue) {
   } = Vue.util
 
   Vue.directive('link-active', {
-    priority: 1001,
+    priority: 651,
     bind () {
       this.el.__v_link_active = true
     }
   })
 
   Vue.directive('link', {
-    priority: 1000,
+    priority: 650,
 
     bind () {
       const vm = this.vm


### PR DESCRIPTION
use-case from @rpkilby:
```html
<a v-link='{name: "home"}' v-on:click='saveTheThing'>Save</a>
```

alternative solution to #390 would be to document this:
```html
<a v-link='{name: "home"}' v-on:click.capture='saveTheThing'>Save</a>
```
(but I can't think of a use case where `v-link` should be evaluated before `v-on`)