### PR TITLE
[2.0.0-beta.2] Set current route to named route if one exists.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "parser": "babel-eslint",
   "extends": "vue",
   "plugins": ["flow-vars"],
+  "env": {
+    "jasmine": true
+  },
   "rules": {
     "flow-vars/define-flow-type": 1,
     "flow-vars/use-flow-type": 1

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -20,7 +20,9 @@ export class History {
   constructor (router: VueRouter, base: ?string) {
     this.router = router
     this.base = normalizeBae(base)
-    this.current = router.match('/')
+    if (router.options && router.options.routes && router.options.routes[0]) {
+      this.current = router.match({ name: router.options.routes[0].name })
+    }
     this.pending = null
     this.transitionTo(this.getLocation())
   }

--- a/test/unit/specs/history.spec.js
+++ b/test/unit/specs/history.spec.js
@@ -1,0 +1,16 @@
+import { History } from '../../../src/history/base'
+import VueRouter from '../../../src'
+
+describe('History', () => {
+  it('Sets name property on current route', () => {
+    const router = new VueRouter({
+      mode: 'history',
+      routes: [
+        { path: '/', name: 'home', component: {}}
+      ]
+    })
+
+    const history = new History(router, '/')
+    expect(history.current.name).toBe('home')
+  })
+})


### PR DESCRIPTION
If named routes are used component instance's `$route.name` will be undefined. That is because `history.current` won't be assigned to named route due to `router.match('/')`.

This implementation is really ugly and probably fails. It's just a discussion starter. Probably we should solve it differently.
