### PR TITLE
[v2.0] Add spec to check if name is set on current route.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "parser": "babel-eslint",
   "extends": "vue",
   "plugins": ["flow-vars"],
+  "env": {
+    "jasmine": true
+  },
   "rules": {
     "flow-vars/define-flow-type": 1,
     "flow-vars/use-flow-type": 1

--- a/src/history/abstract.js
+++ b/src/history/abstract.js
@@ -48,4 +48,8 @@ export class AbstractHistory extends History {
     this.stack = [this.current]
     this.index = 0
   }
+
+  getLocation () {
+    return '/'
+  }
 }

--- a/test/unit/specs/history.spec.js
+++ b/test/unit/specs/history.spec.js
@@ -1,0 +1,16 @@
+import { AbstractHistory } from '../../../src/history/abstract'
+import VueRouter from '../../../src'
+
+describe('History', () => {
+  it('Sets name property on current route', () => {
+    const router = new VueRouter({
+      mode: 'history',
+      routes: [
+        { path: '/', name: 'home', component: {}}
+      ]
+    })
+
+    const history = new AbstractHistory(router)
+    expect(history.current.name).toBe('home')
+  })
+})


### PR DESCRIPTION
Re-opening https://github.com/vuejs/vue-router/pull/584 because it already became stale in the mean time.
## Problem

`name` property of route (defined through router options) won't be transferred to `component.$route.name` as it was the case in previous versions of `vue-router`.
## Added spec in this PR

This spec is intentionally failing because I don't know how to properly fix the bug. `getLocation` method in `abstract.js` was added so we can run this spec.
