### PR TITLE
Expose meta in Route objects

### DIFF
--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -65,6 +65,7 @@ declare type Route = {
   fullPath: string;
   matched: Array<RouteRecord>;
   redirectedFrom?: string;
+  meta?: any;
 }
 
 declare type Matcher = (location: RawLocation, current?: Route) => Route;

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -126,7 +126,7 @@ export function createRoute (
 ): Route {
   const route: Route = {
     name: location.name || (record && record.name),
-    meta: record.meta || {},
+    meta: (record && record.meta) || {},
     path: location.path || '/',
     hash: location.hash || '',
     query: location.query || {},

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -126,6 +126,7 @@ export function createRoute (
 ): Route {
   const route: Route = {
     name: location.name || (record && record.name),
+    meta: record.meta || {},
     path: location.path || '/',
     hash: location.hash || '',
     query: location.query || {},


### PR DESCRIPTION
Expose route.meta to allow reading RouteConfig.meta in transition hooks.

Reasons: 
In 1.0, we used to pass Custom Fields( like `auth` in route configs, as the [document](http://router.vuejs.org/en/route.html#custom-fields) suggested), but in 2.0 these custom fields aren't exposed in `route` object.
I've noticed that in `RouteConfig`, there is an optional field `meta`, which i guess serves the functionality of the previous Custom Fields, judging from the fact that 1). It's type is any 2).there are no usage references of it in the source code. 
So I guess `meta` should be exposed in route objects, otherwise there is no need to define it in the first place.
