### PR TITLE
Fix hash comparison for isSameRoute (fix #635)

### DIFF
--- a/examples/active-links/app.js
+++ b/examples/active-links/app.js
@@ -25,7 +25,7 @@ const router = new VueRouter({
     { path: '/about', component: About },
     { path: '/users', component: Users,
       children: [
-        { path: ':username', component: User }
+        { path: ':username', name: 'user', component: User }
       ]
     }
   ]
@@ -48,6 +48,11 @@ new Vue({
         <li>
           <router-link :to="{ path: '/users/evan', query: { foo: 'bar' }}">
             /users/evan?foo=bar
+          </router-link>
+        </li>
+        <li><!-- #635 -->
+          <router-link :to="{ name: 'user', params: { username: 'evan' }, query: { foo: 'bar' }}" exact>
+            /users/evan?foo=bar (named view + exact match)
           </router-link>
         </li>
         <li>

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -6,13 +6,13 @@ export function isSameRoute (a: Route, b: ?Route): boolean {
   } else if (a.path && b.path) {
     return (
       a.path === b.path &&
-      a.hash === b.hash &&
+      (a.hash || '') === (b.hash || '') &&
       isObjectEqual(a.query, b.query)
     )
   } else if (a.name && b.name) {
     return (
       a.name === b.name &&
-      a.hash === b.hash &&
+      (a.hash || '') === (b.hash || '') &&
       isObjectEqual(a.query, b.query) &&
       isObjectEqual(a.params, b.params)
     )

--- a/test/e2e/specs/active-links.js
+++ b/test/e2e/specs/active-links.js
@@ -3,7 +3,7 @@ module.exports = {
     browser
     .url('http://localhost:8080/active-links/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 10)
+      .assert.count('li a', 11)
       // assert correct href with base
       .assert.attributeContains('li:nth-child(1) a', 'href', '/active-links/')
       .assert.attributeContains('li:nth-child(2) a', 'href', '/active-links/')
@@ -12,9 +12,10 @@ module.exports = {
       .assert.attributeContains('li:nth-child(5) a', 'href', '/active-links/users/evan')
       .assert.attributeContains('li:nth-child(6) a', 'href', '/active-links/users/evan#foo')
       .assert.attributeContains('li:nth-child(7) a', 'href', '/active-links/users/evan?foo=bar')
-      .assert.attributeContains('li:nth-child(8) a', 'href', '/active-links/users/evan?baz=qux&foo=bar')
-      .assert.attributeContains('li:nth-child(9) a', 'href', '/active-links/about')
+      .assert.attributeContains('li:nth-child(8) a', 'href', '/active-links/users/evan?foo=bar')
+      .assert.attributeContains('li:nth-child(9) a', 'href', '/active-links/users/evan?baz=qux&foo=bar')
       .assert.attributeContains('li:nth-child(10) a', 'href', '/active-links/about')
+      .assert.attributeContains('li:nth-child(11) a', 'href', '/active-links/about')
       .assert.containsText('.view', 'Home')
 
     assertActiveLinks(1, [1, 2])
@@ -23,10 +24,11 @@ module.exports = {
     assertActiveLinks(4, [1, 3, 4])
     assertActiveLinks(5, [1, 3, 5])
     assertActiveLinks(6, [1, 3, 5, 6])
-    assertActiveLinks(7, [1, 3, 5, 7])
+    assertActiveLinks(7, [1, 3, 5, 7, 8])
     assertActiveLinks(8, [1, 3, 5, 7, 8])
-    assertActiveLinks(9, [1, 9], [10])
-    assertActiveLinks(10, [1, 9], [10])
+    assertActiveLinks(9, [1, 3, 5, 7, 9])
+    assertActiveLinks(10, [1, 10], [11])
+    assertActiveLinks(11, [1, 10], [11])
 
     browser.end()
 


### PR DESCRIPTION
Fix hash comparison for isSameRoute (#635)
when one of a.hash and b.hash is undefined while the other is empty string

This bug causes active class not being applied when using named view + exact matching
