### PR TITLE
Improve flow declarations

### DIFF
--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -5,6 +5,8 @@ declare module 'path-to-regexp' {
   }
 }
 
+declare type Dictionary<T> = { [key: string]: T }
+
 declare type RouterOptions = {
   routes?: Array<RouteConfig>;
   mode?: string;
@@ -23,7 +25,7 @@ declare type RouteConfig = {
   path: string;
   name?: string;
   component?: any;
-  components?: { [name: string]: any };
+  components?: Dictionary<any>;
   redirect?: RedirectOption;
   alias?: string | Array<string>;
   children?: Array<RouteConfig>;
@@ -37,8 +39,8 @@ declare type RouteConfig = {
 
 declare type RouteRecord = {
   path: string;
-  components: { [name: string]: any };
-  instances: { [name: string]: any };
+  components: Dictionary<any>;
+  instances: Dictionary<any>;
   name: ?string;
   parent: ?RouteRecord;
   redirect: ?RedirectOption;
@@ -51,19 +53,13 @@ declare type RouteRecord = {
   meta: any;
 }
 
-declare type RouteMap = {
-  [key: string]: RouteRecord;
-}
-
-declare type StringHash = { [key: string]: string }
-
 declare type Location = {
   _normalized?: boolean;
   name?: string;
   path?: string;
   hash?: string;
-  query?: StringHash;
-  params?: StringHash;
+  query?: Dictionary<string>;
+  params?: Dictionary<string>;
 }
 
 declare type RawLocation = string | Location
@@ -72,8 +68,8 @@ declare type Route = {
   path: string;
   name: ?string;
   hash: string;
-  query: StringHash;
-  params: StringHash;
+  query: Dictionary<string>;
+  params: Dictionary<string>;
   fullPath: string;
   matched: Array<RouteRecord>;
   redirectedFrom?: string;

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -10,10 +10,14 @@ declare type RouterOptions = {
   mode?: string;
   base?: string;
   linkActiveClass?: string;
-  scrollBehavior?: Function;
+  scrollBehavior?: (
+    to: Route,
+    from: Route,
+    savedPosition: ?{ x: number, y: number }
+  ) => { x: number, y: number } | { selector: string } | ?{};
 }
 
-declare type RedirectOption = RawLocation | Function
+declare type RedirectOption = RawLocation | ((to: Route) => RawLocation)
 
 declare type RouteConfig = {
   path: string;
@@ -23,7 +27,11 @@ declare type RouteConfig = {
   redirect?: RedirectOption;
   alias?: string | Array<string>;
   children?: Array<RouteConfig>;
-  beforeEnter?: Function;
+  beforeEnter?: (
+    route: Route,
+    redirect: (location: RawLocation) => void,
+    next: () => void
+  ) => any;
   meta?: any;
 }
 
@@ -35,7 +43,11 @@ declare type RouteRecord = {
   parent: ?RouteRecord;
   redirect: ?RedirectOption;
   matchAs: ?string;
-  beforeEnter: ?Function;
+  beforeEnter: ?(
+    route: Route,
+    redirect: (location: RawLocation) => void,
+    next: () => void
+  ) => any;
   meta: any;
 }
 

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -4,11 +4,11 @@ import { assert, warn } from './util/warn'
 import { cleanPath } from './util/path'
 
 export function createRouteMap (routes: Array<RouteConfig>): {
-  pathMap: RouteMap,
-  nameMap: RouteMap
+  pathMap: Dictionary<RouteRecord>,
+  nameMap: Dictionary<RouteRecord>
 } {
-  const pathMap: RouteMap = Object.create(null)
-  const nameMap: RouteMap = Object.create(null)
+  const pathMap: Dictionary<RouteRecord> = Object.create(null)
+  const nameMap: Dictionary<RouteRecord> = Object.create(null)
 
   routes.forEach(route => {
     addRouteRecord(pathMap, nameMap, route)
@@ -21,8 +21,8 @@ export function createRouteMap (routes: Array<RouteConfig>): {
 }
 
 function addRouteRecord (
-  pathMap: RouteMap,
-  nameMap: RouteMap,
+  pathMap: Dictionary<RouteRecord>,
+  nameMap: Dictionary<RouteRecord>,
   route: RouteConfig,
   parent?: RouteRecord,
   matchAs?: string

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -86,7 +86,7 @@ export class HTML5History extends History {
         return
       }
       const isObject = typeof shouldScroll === 'object'
-      if (isObject && shouldScroll.selector) {
+      if (isObject && typeof shouldScroll.selector === 'string') {
         const el = document.querySelector(shouldScroll.selector)
         if (el) {
           position = getElementPosition(el)

--- a/src/util/query.js
+++ b/src/util/query.js
@@ -7,8 +7,8 @@ const decode = decodeURIComponent
 
 export function resolveQuery (
   query: ?string,
-  extraQuery: StringHash = {}
-): StringHash {
+  extraQuery: Dictionary<string> = {}
+): Dictionary<string> {
   if (query) {
     let parsedQuery
     try {
@@ -26,7 +26,7 @@ export function resolveQuery (
   }
 }
 
-function parseQuery (query: string): StringHash {
+function parseQuery (query: string): Dictionary<string> {
   const res = Object.create(null)
 
   query = query.trim().replace(/^(\?|#|&)/, '')
@@ -54,7 +54,7 @@ function parseQuery (query: string): StringHash {
   return res
 }
 
-export function stringifyQuery (obj: StringHash): string {
+export function stringifyQuery (obj: Dictionary<string>): string {
   const res = obj ? Object.keys(obj).sort().map(key => {
     const val = obj[key]
 

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -75,7 +75,7 @@ export function isIncludedRoute (current: Route, target: Route): boolean {
   )
 }
 
-function queryIncludes (current: StringHash, target: StringHash): boolean {
+function queryIncludes (current: Dictionary<string>, target: Dictionary<string>): boolean {
   for (const key in target) {
     if (!(key in current)) {
       return false


### PR DESCRIPTION
- update `Function` types to stricter format.
- define `Dictionary<T>` and replace all `{ [name: string}: T }` to it.

I think composing existing types with generics is more understandable than defining a new type alias.
