### PR TITLE
prevent trigger parent link

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -41,7 +41,7 @@ export default {
     const on = {
       click: (e) => {
         e.preventDefault()
-        //prevent trigger parent link
+        // prevent trigger parent link
         e.stopPropagation()
         if (this.replace) {
           router.replace(to)

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -41,6 +41,8 @@ export default {
     const on = {
       click: (e) => {
         e.preventDefault()
+        //prevent trigger parent link
+        e.stopPropagation()
         if (this.replace) {
           router.replace(to)
         } else {


### PR DESCRIPTION
My problem encountered is that:

```
  <router-link tag="li" :to="item.path" data-toggle="dropdown-menu" data-trigger="hover">
      <a>parent menu</a>
      <ul v-if="item.children">
          <router-link v-for="child of item.children"  tag="li" :to="child.path">
               <a>child menu</a>
          </router-link>
      </ul>
  </router-link>
```

When i click a **child menu** , it first trigger the **child menu** and then trigger the **parent menu**, cause the route become **parent menu**.
