### PR TITLE
Fix click event not bound for router-link (fix #707)

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -34,6 +34,7 @@ new Vue({
         <li><router-link to="/">/</router-link></li>
         <li><router-link to="/foo">/foo</router-link></li>
         <li><router-link to="/bar">/bar</router-link></li>
+        <router-link tag="li" to="/bar">/bar</router-link>
       </ul>
       <router-view class="view"></router-view>
     </div>

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -64,6 +64,9 @@ export default {
         aData.on = on
         const aAttrs = aData.attrs || (aData.attrs = {})
         aAttrs.href = href
+      } else {
+        // doesn't have <a> child, apply listener to self
+        data.on = on
       }
     }
 

--- a/test/e2e/specs/basic.js
+++ b/test/e2e/specs/basic.js
@@ -3,6 +3,7 @@ module.exports = {
     browser
     .url('http://localhost:8080/basic/')
       .waitForElementVisible('#app', 1000)
+      .assert.count('li', 4)
       .assert.count('li a', 3)
       // assert correct href with base
       .assert.attributeContains('li:nth-child(1) a', 'href', '/basic/')
@@ -21,6 +22,10 @@ module.exports = {
       .click('li:nth-child(1) a')
       .assert.urlEquals('http://localhost:8080/basic/')
       .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(4)')
+      .assert.urlEquals('http://localhost:8080/basic/bar')
+      .assert.containsText('.view', 'bar')
 
     // check initial visit
     .url('http://localhost:8080/basic/foo')


### PR DESCRIPTION
Fix click event not bound for `<router-link>` when tag is not `<a>` and doesn't have child `<a>`
