### PR TITLE
fix bug beforeEnter fire twice on root path ('/') after async  call

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -15,10 +15,10 @@ export class HashHistory extends History {
     }
 
     ensureSlash()
-    this.transitionTo(getHash())
-
-    window.addEventListener('hashchange', () => {
-      this.onHashChange()
+    this.transitionTo(getHash(), () => {
+      window.addEventListener('hashchange', () => {
+        this.onHashChange()
+      })
     })
   }
 


### PR DESCRIPTION
Issue https://github.com/vuejs/vue-router/issues/725

I might be wrong but I think `this.transitionTo(getHash())` fire the 'hashchange' event, so if next is not called synchronously in beforeEnter function, the second call to transitionTo will trigger beforeEnter again.

Dunno if it's better but we can use setTimeout to deferrer the hashchanged listener, works too.

``` js
ensureSlash()
this.transitionTo(getHash())

setTimeout(() => {
    window.addEventListener('hashchange', () => {
        this.onHashChange()
    })
}, 0)
```
