### PR TITLE
Stop router-link navigation if ctrl-keys or other mouse buttons are clicked. (fix #756)

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -40,6 +40,15 @@ export default {
 
     const on = {
       click: (e) => {
+        // don't redirect with control keys
+        /* istanbul ignore if */
+        if (e.metaKey || e.ctrlKey || e.shiftKey) return
+        // don't redirect when preventDefault called
+        /* istanbul ignore if */
+        if (e.defaultPrevented) return
+        // don't redirect on right click
+        /* istanbul ignore if */
+        if (e.button !== 0) return
         e.preventDefault()
         if (this.replace) {
           router.replace(to)


### PR DESCRIPTION
Fixes #756 

Code is simply copied from 1.0's v-link directive.

Can't test this in Nightwatch as it provides no API to simulate different kinds of mouse events or key presses, at least I don't know how.
