### PR TITLE
Allow calling instance methods before vue instantiation. (fix #795)

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -107,6 +107,14 @@ export class History {
       hook && hook(route, prev)
     })
   }
+
+  /**
+   * Dummy method to make flow happy...
+   * otherwise it won't let me call `this.history.onHashChange`
+   * inside a `switch case`...
+   * Advices on how to remove this method are much appreciated.
+   */
+  onHashChange () {}
 }
 
 function normalizeBase (base: ?string): string {

--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -15,11 +15,6 @@ export class HashHistory extends History {
     }
 
     ensureSlash()
-    this.transitionTo(getHash(), () => {
-      window.addEventListener('hashchange', () => {
-        this.onHashChange()
-      })
-    })
   }
 
   checkFallback () {
@@ -73,7 +68,7 @@ function ensureSlash (): boolean {
   return false
 }
 
-function getHash (): string {
+export function getHash (): string {
   // We can't use window.location.hash here because it's not
   // consistent across browsers - Firefox will pre-decode it!
   const href = window.location.href

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -19,8 +19,6 @@ export class HTML5History extends History {
   constructor (router: VueRouter, base: ?string) {
     super(router, base)
 
-    this.transitionTo(getLocation(this.base))
-
     const expectScroll = router.options.scrollBehavior
     window.addEventListener('popstate', e => {
       _key = e.state && e.state.key


### PR DESCRIPTION
Previously it would throw errors.

Allowed methods: push, replace, go, back, forward

Reason:
These methods only try to manipulate browser history, and should work even when root vue instance has not been created.

Common use case:
Call `router.replace()` to set browser url state. This action doesn't require vue's existence, so it shouldn't throw an error when called before vue's instantiation.
 Otherwise, users may need to check router's actual mode after fallback (history or hash) and then call `history.replaceState` or `location.replace` accordingly.
