### PR TITLE
Allow alias option to be an empty string (Fix #805).

### DIFF
--- a/examples/route-alias/app.js
+++ b/examples/route-alias/app.js
@@ -7,6 +7,7 @@ const Home = { template: '<div><h1>Home</h1><router-view></router-view></div>' }
 const Foo = { template: '<div>foo</div>' }
 const Bar = { template: '<div>bar</div>' }
 const Baz = { template: '<div>baz</div>' }
+const Default = { template: '<div>default</div>' }
 
 const router = new VueRouter({
   mode: 'history',
@@ -19,7 +20,9 @@ const router = new VueRouter({
         // relative alias (alias to /home/bar-alias)
         { path: 'bar', component: Bar, alias: 'bar-alias' },
         // multiple aliases
-        { path: 'baz', component: Baz, alias: ['/baz', 'baz-alias'] }
+        { path: 'baz', component: Baz, alias: ['/baz', 'baz-alias'] },
+        // default child route with empty string as alias.
+        { path: 'default', component: Default, alias: '' }
       ]
     }
   ]
@@ -45,6 +48,10 @@ new Vue({
 
         <li><router-link to="/home/baz-alias">
           /home/baz-alias (renders /home/baz)
+        </router-link></li>
+
+        <li><router-link to="/home">
+          /home (renders /home/default)
         </router-link></li>
       </ul>
       <router-view class="view"></router-view>

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -59,7 +59,7 @@ function addRouteRecord (
     })
   }
 
-  if (route.alias) {
+  if (route.alias !== undefined) {
     if (Array.isArray(route.alias)) {
       route.alias.forEach(alias => {
         addRouteRecord(pathMap, nameMap, { path: alias }, parent, record.path)

--- a/test/e2e/specs/route-alias.js
+++ b/test/e2e/specs/route-alias.js
@@ -3,12 +3,13 @@ module.exports = {
     browser
     .url('http://localhost:8080/route-alias/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 4)
+      .assert.count('li a', 5)
       // assert correct href with base
       .assert.attributeContains('li:nth-child(1) a', 'href', '/route-alias/foo')
       .assert.attributeContains('li:nth-child(2) a', 'href', '/route-alias/home/bar-alias')
       .assert.attributeContains('li:nth-child(3) a', 'href', '/route-alias/baz')
       .assert.attributeContains('li:nth-child(4) a', 'href', '/route-alias/home/baz-alias')
+      .assert.attributeEquals('li:nth-child(5) a', 'href', 'http://localhost:8080/route-alias/home')
 
       .click('li:nth-child(1) a')
       .assert.urlEquals('http://localhost:8080/route-alias/foo')
@@ -29,6 +30,10 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/route-alias/home/baz-alias')
       .assert.containsText('.view', 'Home')
       .assert.containsText('.view', 'baz')
+      .click('li:nth-child(5) a')
+      .assert.urlEquals('http://localhost:8080/route-alias/home')
+      .assert.containsText('.view', 'Home')
+      .assert.containsText('.view', 'default')
 
     // check initial visit
     .url('http://localhost:8080/route-alias/foo')
@@ -54,6 +59,12 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/route-alias/home/baz-alias')
       .assert.containsText('.view', 'Home')
       .assert.containsText('.view', 'baz')
+
+    .url('http://localhost:8080/route-alias/home')
+      .waitForElementVisible('#app', 1000)
+      .assert.urlEquals('http://localhost:8080/route-alias/home')
+      .assert.containsText('.view', 'Home')
+      .assert.containsText('.view', 'default')
       .end()
   }
 }


### PR DESCRIPTION
Fixes #805 
Previoulsly, alias paths were only added to the map when `if (route.alias)`. empty strings failed this test.
