### PR TITLE
Correct replaceHash function

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -88,6 +88,6 @@ function pushHash (path) {
 function replaceHash (path) {
   const i = window.location.href.indexOf('#')
   window.location.replace(
-    window.location.href.slice(0, i >= 0 ? i : 0) + '#' + path
+    window.location.href.slice(0, i >= 0 ? i : window.location.href.length) + '#' + path
   )
 }


### PR DESCRIPTION
Replace slice 0 to 0 when there is no hash with slice 0 to url length. 
Exemple if the application is on a suburl as http://www.exemple/app/ a replace is done from http://www.exemple.com/app/ to http://www.exemple.com/#/ instead of http://www.exemple.com/app#/. This changement allow to correct that and keep the root.
