### PR TITLE
Fix lazy-loading routes with Webpack 2

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -205,7 +205,9 @@ function resolveAsyncComponents (matched: Array<RouteRecord>): Array<?Function> 
     if (typeof def === 'function' && !def.options) {
       return (to, from, next) => {
         const resolve = resolvedDef => {
-          match.components[key] = resolvedDef
+          if (resolvedDef) {
+            match.components[key] = resolvedDef
+          }
           next()
         }
 


### PR DESCRIPTION
Hi,

I'm using Webpack 2 and there is a bug on the resolve method inside `resolveAsyncComponents`.
It seems by using Webpack 2, resolve is called twice, first with the resolved Component, and second with undefined.

You can reproduce this error by the fork I made:
```bash
git clone https://github.com/Atinux/vue-router-bug.git
cd vue-router-bug
npm install
npm run dev
``` 

Then, go to [http://localhost:8080/lazy-loading/](http://localhost:8080/lazy-loading/) and navigate between the links.

Please see it in action:
<img src="http://g.recordit.co/vXSYubRSlE.gif" />

My fix if to only check if resolvedDef is defined before updating the matched route.components.

Thank you :fire: