### PR TITLE
[1.0] Conditional saving of scroll position in HTML5 history backend

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -16,7 +16,7 @@ export default class HTML5History {
       this.root = null
     }
     this.onChange = onChange
-    this.saveScrollPosition = saveScrollPosition;
+    this.saveScrollPosition = saveScrollPosition
     // check base tag
     const baseEl = document.querySelector('base')
     this.base = baseEl && baseEl.getAttribute('href')

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -3,7 +3,7 @@ const hashRE = /#.*$/
 
 export default class HTML5History {
 
-  constructor ({ root, onChange }) {
+  constructor ({ root, onChange, saveScrollPosition }) {
     if (root && root !== '/') {
       // make sure there's the starting slash
       if (root.charAt(0) !== '/') {
@@ -16,6 +16,7 @@ export default class HTML5History {
       this.root = null
     }
     this.onChange = onChange
+    this.saveScrollPosition = saveScrollPosition;
     // check base tag
     const baseEl = document.querySelector('base')
     this.base = baseEl && baseEl.getAttribute('href')
@@ -42,13 +43,15 @@ export default class HTML5History {
     if (replace) {
       history.replaceState({}, '', url)
     } else {
-      // record scroll position by replacing current state
-      history.replaceState({
-        pos: {
-          x: window.pageXOffset,
-          y: window.pageYOffset
-        }
-      }, '', location.href)
+      if (this.saveScrollPosition) {
+        // record scroll position by replacing current state
+        history.replaceState({
+          pos: {
+            x: window.pageXOffset,
+            y: window.pageYOffset
+          }
+        }, '', location.href)
+      }
       // then push new state
       history.pushState({}, '', url)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,8 @@ class Router {
       hashbang: this._hashbang,
       onChange: (path, state, anchor) => {
         this._match(path, state, anchor)
-      }
+      },
+      saveScrollPosition: saveScrollPosition
     })
 
     // other options


### PR DESCRIPTION
Scroll position is saved only when ```saveScrollPosition``` router option is set.

This fixes integration of [autotrack](https://github.com/googleanalytics/autotrack/) with vue-router.
Additional replaceState() call doesn't play well with [urlChangeTracker plugin](https://github.com/googleanalytics/autotrack/blob/master/docs/plugins/url-change-tracker.md) and causes that ```pageview``` isn't sent.