### PR TITLE
avoid rearrange query params

### DIFF
--- a/src/util/query.js
+++ b/src/util/query.js
@@ -55,7 +55,7 @@ function parseQuery (query: string): Dictionary<string> {
 }
 
 export function stringifyQuery (obj: Dictionary<string>): string {
-  const res = obj ? Object.keys(obj).sort().map(key => {
+  const res = obj ? Object.keys(obj).map(key => {
     const val = obj[key]
 
     if (val === undefined) {


### PR DESCRIPTION
avoid rearrange query parameters, 
coz it will cost a new request 
and make some troubles like generating token which is based on query string