### PR TITLE
Fix .getAttribute on an element without this method

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -94,8 +94,10 @@ function guardEvent (e) {
   if (e.button !== 0) return
   // don't redirect if `target="_blank"`
   /* istanbul ignore if */
-  const target = e.target.getAttribute('target')
-  if (/\b_blank\b/i.test(target)) return
+  if (e.target && e.target.getAttribute) {
+    const target = e.target.getAttribute('target')
+    if (/\b_blank\b/i.test(target)) return
+  }
 
   e.preventDefault()
   return true


### PR DESCRIPTION
Hello,

I had an error about `object doesn't support property or method 'getAttribute'` on IE (mainly Cordova on windows desktop) by clicking on a generated link by `<router-link>`.

```html
<ul>
     <li>
        <router-link class="MainNav-item" :to="{name: 'ArtistListing'}">
          <span class="MainNav-icon"><icon name="micro"></icon></span>
          Artists
        </router-link>
      </li>
      <li>
        <router-link class="MainNav-item" :to="{name: 'CompetitionListing'}">
          <span class="MainNav-icon"><icon name="cup"></icon></span>
          Competition
        </router-link>
      </li>
</ul>
```

When you click on the generated link, sometimes in `src/components/link.js` in the method https://github.com/AnthonySendra/vue-router/blob/d065e37e0e19f399597796b5257bfca3a5c79fd6/src/components/link.js#L85 the `e.target` can be an instance of [SVGElementInstance](http://mcc.id.au/temp/2007/svg11-javadoc/org/w3c/dom/svg/SVGElementInstance.html). But this object does not have the method `getAttribute`. This error causes the application (Cordova) to crash.

My fix will check if the object (the `e.target`) has the method `getAttribute` before calling it.