### PR TITLE
make use of user timing api if available

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -2,6 +2,7 @@
 
 import type VueRouter from '../index'
 import { assert } from '../util/warn'
+import { inBrowser } from '../util/dom'
 import { cleanPath } from '../util/path'
 import { History } from './base'
 import {
@@ -12,7 +13,10 @@ import {
   getElementPosition
 } from '../util/scroll-position'
 
-const genKey = () => String(Date.now())
+// use User Timing api (if present) for more accurate key precision
+const Time = inBrowser ? (window.performance || Date) : Date
+
+const genKey = () => String(Time.now())
 let _key: string = genKey()
 
 export class HTML5History extends History {


### PR DESCRIPTION
This introduces a client-side check for availability of the [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) and augments the `genKey` function to use `performance.now` instead of `Date.now` if the User Timing API is available.

The benefits of this change are:
- the accuracy of the resulting `_key` is more precise in modern browsers (more specifically, instead of being a value that represents milliseconds since the unix epoch, it represents microseconds since the user started navigating - because microseconds are a smaller unit of measurement than milliseconds, this might generate more `_key`s)
- mitigates a false negative on [Lighthouse](https://github.com/googlechrome/lighthouse) (giving apps that use `vue-router` a better score for being a progressive web app)