### PR TITLE
 decode URI when aborting transition (Fix #760)

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -14,7 +14,7 @@ function warn (msg) {
   }
 }
 
-function tryDecode (uri, asComponent) {
+export function tryDecode (uri, asComponent) {
   try {
     return asComponent
       ? decodeURIComponent(uri)

--- a/src/transition.js
+++ b/src/transition.js
@@ -46,6 +46,8 @@ export default class RouteTransition {
       // on initial load, it gets caught in an infinite loop.
       const abortingOnLoad = !this.from.path && this.to.path === '/'
       if (!abortingOnLoad) {
+        // When aborting, we have to decode the Path, because router.replace()
+        // will encode it again. (https://github.com/vuejs/vue-router/issues/760)
         const path = this.from.path ? tryDecode(this.from.path, true) : '/'
         this.router.replace(path)
       }

--- a/src/transition.js
+++ b/src/transition.js
@@ -13,6 +13,7 @@ import {
   canReuse
 } from './pipeline'
 
+import { tryDecode } from '../lib/route-recognizer'
 /**
  * A RouteTransition object manages the pipeline of a
  * router-view switching process. This is also the object
@@ -45,7 +46,8 @@ export default class RouteTransition {
       // on initial load, it gets caught in an infinite loop.
       const abortingOnLoad = !this.from.path && this.to.path === '/'
       if (!abortingOnLoad) {
-        this.router.replace(this.from.path || '/')
+        const path = this.from.path ? tryDecode(this.from.path, true) : '/'
+        this.router.replace(path)
       }
     }
   }


### PR DESCRIPTION
(Fixes #760)

### Problem

When aborting a transition, and the URL contained escaped chars, the chars would be escaped again. I added a decode in between to make this work again. 