### PR TITLE
Fix #1012 same route transitions guard execution

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -49,18 +49,13 @@ export class History {
       return abort()
     }
 
-    const {
-      deactivated,
-      activated
-    } = resolveQueue(this.current.matched, route.matched)
-
     const queue: Array<?NavigationGuard> = [].concat(
       // in-component leave guards
-      extractLeaveGuards(deactivated),
+      extractLeaveGuards(this.current.matched),
       // global before hooks
       this.router.beforeHooks,
       // enter guards
-      activated.map(m => m.beforeEnter),
+      route.matched.matched.map(m => m.beforeEnter),
       // async components
       resolveAsyncComponents(activated)
     )
@@ -134,26 +129,6 @@ function normalizeBase (base: ?string): string {
   }
   // remove trailing slash
   return base.replace(/\/$/, '')
-}
-
-function resolveQueue (
-  current: Array<RouteRecord>,
-  next: Array<RouteRecord>
-): {
-  activated: Array<RouteRecord>,
-  deactivated: Array<RouteRecord>
-} {
-  let i
-  const max = Math.max(current.length, next.length)
-  for (i = 0; i < max; i++) {
-    if (current[i] !== next[i]) {
-      break
-    }
-  }
-  return {
-    activated: next.slice(i),
-    deactivated: current.slice(i)
-  }
 }
 
 function extractGuard (

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -57,7 +57,7 @@ export class History {
       // enter guards
       route.matched.matched.map(m => m.beforeEnter),
       // async components
-      resolveAsyncComponents(activated)
+      resolveAsyncComponents(route.matched)
     )
 
     this.pending = route

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -55,7 +55,7 @@ export class History {
       // global before hooks
       this.router.beforeHooks,
       // enter guards
-      route.matched.matched.map(m => m.beforeEnter),
+      route.matched.map(m => m.beforeEnter),
       // async components
       resolveAsyncComponents(route.matched)
     )

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -83,7 +83,7 @@ export class History {
 
     runQueue(queue, iterator, () => {
       const postEnterCbs = []
-      const enterGuards = extractEnterGuards(activated, postEnterCbs, () => {
+      const enterGuards = extractEnterGuards(route.matched, postEnterCbs, () => {
         return this.current === route
       })
       // wait until async components are resolved before


### PR DESCRIPTION
#1012 - Removing the `resolveQueue` function and simply using the `route.matched` and `this.current.matched` as the means for executing the guards resolves this issue.

Consider the following route:

```javascript
{
    path: '/users/:id',
    name: UserProfile,
    beforeEnter: function(from, to, next) {
        // fetch user record from API and put into Vuex
        next()
    }
}
```

If the application was currently on the route `/users/joe` and was navigating to `/users/paul`, the `beforeEnter` guard for the route would not be executed. Therefore, the `paul` user record would not be fetched and stored in Vuex. Removing the guard execution queue resolution (aka. `resolveQueue`) ensures that the aforementioned use case works. 