### PR TITLE
Fixes #1012 same route guard execution

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -49,10 +49,8 @@ export class History {
       return abort()
     }
 
-    const {
-      deactivated,
-      activated
-    } = resolveQueue(this.current.matched, route.matched)
+    const activated = route.matched
+    const deactivated = this.current.matched
 
     const queue: Array<?NavigationGuard> = [].concat(
       // in-component leave guards
@@ -134,26 +132,6 @@ function normalizeBase (base: ?string): string {
   }
   // remove trailing slash
   return base.replace(/\/$/, '')
-}
-
-function resolveQueue (
-  current: Array<RouteRecord>,
-  next: Array<RouteRecord>
-): {
-  activated: Array<RouteRecord>,
-  deactivated: Array<RouteRecord>
-} {
-  let i
-  const max = Math.max(current.length, next.length)
-  for (i = 0; i < max; i++) {
-    if (current[i] !== next[i]) {
-      break
-    }
-  }
-  return {
-    activated: next.slice(i),
-    deactivated: current.slice(i)
-  }
 }
 
 function extractGuard (


### PR DESCRIPTION
#1012 - Removing the `resolveQueue` function and simply using the `route.matched` and `this.current.matched` as the means for executing the guards resolves this issue.
