### PR TITLE
make it runable in windows

### DIFF
--- a/test/e2e/nightwatch.config.js
+++ b/test/e2e/nightwatch.config.js
@@ -11,7 +11,7 @@ module.exports = {
     'host': '127.0.0.1',
     'port': 4444,
     'cli_args': {
-      'webdriver.chrome.driver': 'node_modules/chromedriver/lib/chromedriver/chromedriver'
+      'webdriver.chrome.driver': require('chromedriver').path
     }
   },
 


### PR DESCRIPTION
In windows, `npm test` will throw following error:
```
Error retrieving a new session from the selenium server

Connection refused! Is selenium server started?
{ state: 'unhandled error',
  sessionId: null,
  hCode: 1588760960,
  value:
   { localizedMessage: 'The driver executable does not exist: C:\\xxx\\vue-router\\node_modu
les\\chromedriver\\lib\\chromedriver\\chromedriver',
     cause: null,
     suppressed: [],
     message: 'The driver executable does not exist: C:\\xxx\\vue-router\\node_modules\\chro
medriver\\lib\\chromedriver\\chromedriver',
     hCode: 1631501449,
     class: 'java.lang.IllegalStateException',
     screen: null },
  class: 'org.openqa.selenium.remote.Response',
  status: 13 }
```

This PR fixed this problem.