### PR TITLE
Custom encodequery

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -14,11 +14,13 @@ const Bar = { template: '<div>bar</div>' }
 // 3. Create the router
 const router = new VueRouter({
   mode: 'history',
+  encodeQuery: false,
   base: __dirname,
   routes: [
     { path: '/', component: Home },
     { path: '/foo', component: Foo },
-    { path: '/bar', component: Bar }
+    { path: '/bar', component: Bar },
+    { path: '/query', component: Bar }
   ]
 })
 
@@ -37,6 +39,7 @@ new Vue({
         <router-link tag="li" to="/bar" :event="['mousedown', 'touchstart']">
           <a>/bar</a>
         </router-link>
+        <li><router-link to="/query?opts=a,b,c">/query?opts=a,b,c</router-link></li>
       </ul>
       <router-view class="view"></router-view>
     </div>

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -57,6 +57,7 @@ declare type Location = {
   path?: string;
   hash?: string;
   query?: Dictionary<string>;
+  encodeQuery?: Function | boolean;
   params?: Dictionary<string>;
   append?: boolean;
   replace?: boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -138,6 +138,9 @@ export default class VueRouter {
     href: string
   } {
     const normalizedTo = normalizeLocation(to, current || this.history.current, append)
+    normalizedTo.encodeQuery = normalizedTo.encodeQuery === undefined
+      ? this.options.encodeQuery
+      : normalizedTo.encodeQuery
     const resolved = this.match(normalizedTo, current)
     const fullPath = resolved.redirectedFrom || resolved.fullPath
     const base = this.history.base

--- a/src/util/location.js
+++ b/src/util/location.js
@@ -48,6 +48,7 @@ export function normalizeLocation (
     _normalized: true,
     path,
     query,
+    encodeQuery: next.encodeQuery,
     hash
   }
 }

--- a/src/util/query.js
+++ b/src/util/query.js
@@ -2,7 +2,7 @@
 
 import { warn } from './warn'
 
-const encode = encodeURIComponent
+const noEncode = s => s
 const decode = decodeURIComponent
 
 export function resolveQuery (
@@ -54,7 +54,15 @@ function parseQuery (query: string): Dictionary<string> {
   return res
 }
 
-export function stringifyQuery (obj: Dictionary<string>): string {
+export function stringifyQuery (
+  obj: Dictionary<string>,
+  encodeQuery: Function | boolean = true
+): string {
+  // use the encodeURIComponent by default
+  // if false, don't encode, otherwise use encodeQuery as a function
+  const encode = encodeQuery === true
+          ? encodeURIComponent
+          : encodeQuery || noEncode
   const res = obj ? Object.keys(obj).map(key => {
     const val = obj[key]
 

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -37,8 +37,8 @@ function formatMatch (record: ?RouteRecord): Array<RouteRecord> {
   return res
 }
 
-function getFullPath ({ path, query = {}, hash = '' }) {
-  return (path || '/') + stringifyQuery(query) + hash
+function getFullPath ({ path, query = {}, hash = '', encodeQuery }) {
+  return (path || '/') + stringifyQuery(query, encodeQuery) + hash
 }
 
 const trailingSlashRE = /\/$/

--- a/test/e2e/specs/basic.js
+++ b/test/e2e/specs/basic.js
@@ -28,6 +28,10 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/basic/bar')
       .assert.containsText('.view', 'bar')
 
+      .click('li:nth-child(5) a')
+      .assert.urlEquals('http://localhost:8080/basic/query?opts=a,b,c')
+      .assert.containsText('.view', 'bar')
+
     // check initial visit
     .url('http://localhost:8080/basic/foo')
       .waitForElementVisible('#app', 1000)

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -1,5 +1,9 @@
 import { resolveQuery, stringifyQuery } from '../../../src/util/query'
 
+function encodeURIAndKeepCommas (str) {
+  return encodeURIComponent(str).replace('%2C', ',')
+}
+
 describe('Query utils', () => {
   describe('resolveQuery', () => {
     it('should work', () => {
@@ -18,6 +22,24 @@ describe('Query utils', () => {
         baz: 'qux',
         arr: [1, 2]
       })).toBe('?foo=bar&baz=qux&arr=1&arr=2')
+    })
+
+    it('custom encodeQuery', () => {
+      expect(
+        stringifyQuery({
+          foo: 'bar,bar',
+          baz: 'foo;foo'
+        }, encodeURIAndKeepCommas)
+      ).toBe('?foo=bar,bar&baz=foo%3Bfoo')
+    })
+
+    it('not encode query', () => {
+      expect(
+        stringifyQuery({
+          foo: 'bar,bar',
+          baz: 'foo;foo'
+        }, false)
+      ).toBe('?foo=bar,bar&baz=foo;foo')
     })
   })
 })

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -78,10 +78,12 @@ export interface RouteRecord {
 }
 
 export interface Location {
+  _normalized?: boolean;
   name?: string;
   path?: string;
   hash?: string;
   query?: Dictionary<string>;
+  encodeQuery?: Function | boolean;
   params?: Dictionary<string>;
   append?: boolean;
   replace?: boolean;


### PR DESCRIPTION
Let me know if this implementation and the api are good enough so I can update the docs too

---
Closes #1027
Pass a function to use it instead of encodeURIComponent or pass false to
pass query arguments without encoding them. This would allow you to
encode only some characters doing something like
`encodeURIComponent(queryValue).replace('%2C', ',')`
would keep the commas on your query arguments.
⚠️ Setting it to false should only be used if you have other kinds of
sanitizations going on or if you're sure the query variables are URI
safe.