### PR TITLE
Check for performance.now support

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -15,7 +15,7 @@ import {
 
 // use User Timing api (if present) for more accurate key precision
 // IE 9 supports performance API but doesn't have performance.now
-const Time = inBrowser ? (window.performance.now ? window.performance : Date) : Date
+const Time = inBrowser ? (window.performance && window.performance.now ? window.performance : Date) : Date
 
 const genKey = () => String(Time.now())
 let _key: string = genKey()

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -14,7 +14,8 @@ import {
 } from '../util/scroll-position'
 
 // use User Timing api (if present) for more accurate key precision
-const Time = inBrowser ? (window.performance || Date) : Date
+// IE 9 supports performance API but doesn't have performance.now
+const Time = inBrowser ? (window.performance.now ? window.performance : Date) : Date
 
 const genKey = () => String(Time.now())
 let _key: string = genKey()


### PR DESCRIPTION
Fix #1104

IE 9 supports the performance API but doesn't have the now method. Since we're relying specifically on that one, better directly check for performance.now

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
