### PR TITLE
Add unpkg to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
     "vue-template-compiler": "^2.1.0",
     "webpack": "^2.2.0",
     "webpack-dev-middleware": "^1.9.0"
-  }
+  },
+  "unpkg": "dist/vue-router.js"
 }


### PR DESCRIPTION
Make the package usable with https://unpkg.com/vue-router
instead of https://unpkg.com/vue-router/dist/vue-router.js

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
