### PR TITLE
[Feature] add param cast option

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -15,6 +15,7 @@
     <li><a href="route-matching">Route Matching</a></li>
     <li><a href="active-links">Active Links</a></li>
     <li><a href="redirect">Redirect</a></li>
+    <li><a href="route-params-cast">Route Parameter Casting</a></li>
     <li><a href="route-props">Route Props</a></li>
     <li><a href="route-alias">Route Alias</a></li>
     <li><a href="transitions">Transitions</a></li>

--- a/examples/route-params-cast/Hello.vue
+++ b/examples/route-params-cast/Hello.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <h2 class="hello">Hello {{ name }}</h2>
+    <p class="type">this.name is a: <b>{{ type }}<b></p>
+  </div>
+</template>
+
+<script>
+
+export default {
+  computed: {
+    name () {
+      return this.$route.params.name || 'Vue!'
+    },
+    type () {
+      return typeof this.name
+    }
+  }
+}
+</script>

--- a/examples/route-params-cast/app.js
+++ b/examples/route-params-cast/app.js
@@ -1,0 +1,32 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+import Hello from './Hello.vue'
+
+Vue.use(VueRouter)
+
+const router = new VueRouter({
+  mode: 'history',
+  base: __dirname,
+  routes: [
+    { path: '/', component: Hello }, // No params, no nothing
+    { path: '/hello/:name', component: Hello }, // Cast to type Number
+    { path: '/number/:name', component: Hello, params: { name: Number }}, // Cast to type Number
+    { path: '/exclamation/:name', component: Hello, params: { name: value => `${value}!` }} // custom logic for casting params
+  ]
+})
+
+new Vue({
+  router,
+  template: `
+    <div id="app">
+      <h1>Route props</h1>
+      <ul>
+        <li><router-link to="/">/</router-link></li>
+        <li><router-link to="/hello/you">/hello/you</router-link></li>
+        <li><router-link to="/number/3">/number/3</router-link></li>
+        <li><router-link to="/exclamation/1">/exclamation/1</router-link></li>
+      </ul>
+      <router-view class="view"></router-view>
+    </div>
+  `
+}).$mount('#app')

--- a/examples/route-params-cast/index.html
+++ b/examples/route-params-cast/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/global.css">
+<a href="/">&larr; Examples index</a>
+<div id="app"></div>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/route-params-cast.js"></script>

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -27,6 +27,8 @@ declare type RouterOptions = {
 
 declare type RedirectOption = RawLocation | ((to: Route) => RawLocation)
 
+declare type ParamCastFunction = (value: string) => any
+
 declare type RouteConfig = {
   path: string;
   name?: string;
@@ -37,6 +39,7 @@ declare type RouteConfig = {
   children?: Array<RouteConfig>;
   beforeEnter?: NavigationGuard;
   meta?: any;
+  params?: Dictionary<ParamCastFunction>;
   props?: boolean | Object | Function;
 }
 
@@ -50,6 +53,7 @@ declare type RouteRecord = {
   matchAs: ?string;
   beforeEnter: ?NavigationGuard;
   meta: any;
+  params: Dictionary<ParamCastFunction>;
   props: boolean | Object | Function | Dictionary<boolean | Object | Function>;
 }
 
@@ -71,7 +75,7 @@ declare type Route = {
   name: ?string;
   hash: string;
   query: Dictionary<string>;
-  params: Dictionary<string>;
+  params: Dictionary<any>;
   fullPath: string;
   matched: Array<RouteRecord>;
   redirectedFrom?: string;

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -51,6 +51,7 @@ function addRouteRecord (
     redirect: route.redirect,
     beforeEnter: route.beforeEnter,
     meta: route.meta || {},
+    params: route.params || {},
     props: route.props == null
       ? {}
       : route.components

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -9,13 +9,23 @@ export function createRoute (
   location: Location,
   redirectedFrom?: Location
 ): Route {
+  // Cast params
+  const params: Object = {}
+  const locationParams: Object = location.params || {}
+  const recordParams: Dictionary<ParamCastFunction> = (record && record.params) || {}
+  Object.keys(locationParams).forEach((key: string): void => {
+    const value: string = locationParams[key]
+    const caster: ParamCastFunction = recordParams[key]
+    params[key] = caster ? caster(value) : value
+  })
+
   const route: Route = {
     name: location.name || (record && record.name),
     meta: (record && record.meta) || {},
     path: location.path || '/',
     hash: location.hash || '',
     query: location.query || {},
-    params: location.params || {},
+    params,
     fullPath: getFullPath(location),
     matched: record ? formatMatch(record) : []
   }

--- a/test/e2e/specs/route-params-cast.js
+++ b/test/e2e/specs/route-params-cast.js
@@ -1,0 +1,30 @@
+module.exports = {
+  'route-params-cast': function (browser) {
+    browser
+    .url('http://localhost:8080/route-params-cast/')
+      .waitForElementVisible('#app', 1000)
+      .assert.count('li a', 4)
+
+      .click('li:nth-child(1) a')
+      .assert.urlEquals('http://localhost:8080/route-params-cast/')
+      .assert.containsText('.hello', 'Hello Vue!')
+      .assert.containsText('.type', 'string')
+
+      .click('li:nth-child(2) a')
+      .assert.urlEquals('http://localhost:8080/route-params-cast/hello/you')
+      .assert.containsText('.hello', 'Hello you')
+      .assert.containsText('.type', 'string')
+
+      .click('li:nth-child(3) a')
+      .assert.urlEquals('http://localhost:8080/route-params-cast/number/3')
+      .assert.containsText('.hello', 'Hello 3')
+      .assert.containsText('.type', 'number')
+
+      .click('li:nth-child(4) a')
+      .assert.urlEquals('http://localhost:8080/route-params-cast/exclamation/1')
+      .assert.containsText('.hello', 'Hello 1!')
+      .assert.containsText('.type', 'string')
+
+      .end()
+  }
+}

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -55,6 +55,7 @@ export interface RouterOptions {
 }
 
 type RoutePropsFunction = (route: Route) => Object;
+type RouteParamsFunction = (value: string) => any;
 
 export interface RouteConfig {
   path: string;
@@ -66,6 +67,7 @@ export interface RouteConfig {
   children?: RouteConfig[];
   meta?: any;
   beforeEnter?: NavigationGuard;
+  params?: Dictionary<RouteParamsFunction>;
   props?: boolean | Object | RoutePropsFunction;
 }
 
@@ -101,7 +103,7 @@ export interface Route {
   name?: string;
   hash: string;
   query: Dictionary<string>;
-  params: Dictionary<string>;
+  params: Dictionary<any>;
   fullPath: string;
   matched: RouteRecord[];
   redirectedFrom?: string;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -82,6 +82,7 @@ const router = new VueRouter({
     { path: "/foo", props: true },
     { path: "/bar", props: { id: 123 }},
     { path: "/baz", props: (route: Route) => route.params },
+    { path: "/number/:id", params: { id: Number }},
     { path: "*", redirect: "/" }
   ]
 });


### PR DESCRIPTION
#Add param casting options. It is quite often that you wish to cast the params to a number or for custom decoding options.

This is achievable currently through custom prop option as function, however this is limited to the scope of the prop feature. Use of `this.$route.params` or `this.$store.route.params` will always be of type string which means often casting around the application.

This feature allows casting at a single point (the definition)

```js
{
  path: '/number/:id',
  params: {
    id: Number, 

    // or custom cast function
    id: value => Number(value) + 1
  }
}
```

If this approved i can commit changes to the documentation, to correct current incorrect information (https://github.com/vuejs/vue-router/blob/master/docs/en/route.md#dynamic-segments), and to document new feature. 