### PR TITLE
[Feature] resolve props for router.getMatchedComponents

### DIFF
--- a/docs/en/api/router-instance.md
+++ b/docs/en/api/router-instance.md
@@ -38,7 +38,7 @@
 
 - **router.getMatchedComponents(location?)**
 
-  Returns an Array of the components (definition/constructor, not instances) matched by the provided location or the current route. This is mostly used during server-side rendering to perform data prefetching.
+  Returns an Array of the components (definition/constructor, not instances) matched by the provided location or the current route. This is mostly used during server-side rendering to perform data prefetching. Resolved props are available on `$props` for each component.
 
 - **router.resolve(location, current?, append?)**
 

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -37,7 +37,7 @@ declare type RouteConfig = {
   children?: Array<RouteConfig>;
   beforeEnter?: NavigationGuard;
   meta?: any;
-  props?: boolean | Object | Function;
+  props?: any;
 }
 
 declare type RouteRecord = {
@@ -50,7 +50,7 @@ declare type RouteRecord = {
   matchAs: ?string;
   beforeEnter: ?NavigationGuard;
   meta: any;
-  props: boolean | Object | Function | Dictionary<boolean | Object | Function>;
+  props: Dictionary<boolean | Object | Function>;
 }
 
 declare type Location = {

--- a/src/components/view.js
+++ b/src/components/view.js
@@ -1,4 +1,4 @@
-import { warn } from '../util/warn'
+import { resolveProps } from '../util/props'
 
 export default {
   name: 'router-view',
@@ -60,23 +60,8 @@ export default {
     }
 
     // resolve props
-    data.props = resolveProps(route, matched.props && matched.props[name])
+    data.props = resolveProps(route, matched.props[name])
 
     return h(component, data, children)
-  }
-}
-
-function resolveProps (route, config) {
-  switch (typeof config) {
-    case 'undefined':
-      return
-    case 'object':
-      return config
-    case 'function':
-      return config(route)
-    case 'boolean':
-      return config ? route.params : undefined
-    default:
-      warn(false, `props in "${route.path}" is a ${typeof config}, expecting an object, function or boolean.`)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { START } from './util/route'
 import { assert } from './util/warn'
 import { inBrowser } from './util/dom'
 import { cleanPath } from './util/path'
+import { resolveProps } from './util/props'
 import { createMatcher } from './create-matcher'
 import { normalizeLocation } from './util/location'
 import { supportsPushState } from './util/push-state'
@@ -157,6 +158,7 @@ export default class VueRouter {
     }
     return [].concat.apply([], route.matched.map(m => {
       return Object.keys(m.components).map(key => {
+        m.components[key].$props = resolveProps(route, m.props[key])
         return m.components[key]
       })
     }))

--- a/src/util/props.js
+++ b/src/util/props.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import { warn } from './warn'
+
+export function resolveProps (route: Route, props: boolean | Object | Function): any {
+  switch (typeof props) {
+    case 'undefined':
+      return
+    case 'object':
+      return props
+    case 'function':
+      return props(route)
+    case 'boolean':
+      return props ? route.params : undefined
+    default:
+      warn(false, `props in "${route.path}" is a ${typeof props}, expecting an object, function or boolean.`)
+  }
+}

--- a/test/unit/specs/props.spec.js
+++ b/test/unit/specs/props.spec.js
@@ -1,0 +1,40 @@
+import { resolveProps } from '../../../src/util/props'
+
+describe('Props utils', () => {
+  describe('resolveProps', () => {
+    beforeAll(() => {
+      spyOn(console, 'warn')
+    })
+
+    it('undefined', () => {
+      const result = resolveProps()
+      expect(result).toBeUndefined()
+    })
+
+    it('object', () => {
+      const result = resolveProps(null, { test: 'yes' })
+      expect(result).toEqual({ test: 'yes' })
+    })
+
+    it('function', () => {
+      const result = resolveProps(null, () => ({ test: 'yes' }))
+      expect(result).toEqual({ test: 'yes' })
+    })
+
+    it('true (inherit route params)', () => {
+      const result = resolveProps({ params: { test: 'yes' }}, true)
+      expect(result).toEqual({ test: 'yes' })
+    })
+
+    it('false', () => {
+      const result = resolveProps({ params: { test: 'yes' }}, false)
+      expect(result).toBeUndefined()
+    })
+
+    it('warns on unsuported type', () => {
+      resolveProps({ params: { test: 'yes' }}, 0)
+      expect(console.warn).toHaveBeenCalled()
+      expect(console.warn.calls.argsFor(0)[0]).toMatch('vue-router] props in ')
+    })
+  })
+})


### PR DESCRIPTION
The new props feature allows to decouple components. However when using SSR you normally do preFetch the component data. This means we are once again coupled between the router and the component. 

Current scenario:
```js
  function preFetch(store) {
    const id = store.route.params.id;
    // Do something with id
  }

  export default {
    preFetch,
    beforeMount() {
      preFetch(this.$store);
    },
  };
```

By resolving the props to `$props` on components retrieved from `router.getMatchedComponents` we are able to use the props feature to keep components and the router decoupled with SSR.

Decoupled component:
```js
  function preFetch(store, props) {
    const id = props.id;
    // Do something with id
  }

  export default {
    name: 'IndexPage',

    props: {
      test: String,
    },

    preFetch,
    beforeMount() {
      preFetch(this.$store, this.$options.propsData);
    },
  };
```

preFetch: 
```js
  await Promise.all(
    entry.router.getMatchedComponents()
      .filter(component => component.preFetch && component.preFetch)
      .map(component => component.preFetch(entry.store, component.$props)),
  );
``` 