### PR TITLE
Change edit link base

### DIFF
--- a/docs/book.json
+++ b/docs/book.json
@@ -3,7 +3,7 @@
   "plugins": ["edit-link", "theme-vuejs@git+https://github.com/pearofducks/gitbook-plugin-theme-vuejs.git", "-fontsettings", "github"],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/vuejs/vue-router/tree/master/docs",
+      "base": "https://github.com/vuejs/vue-router/tree/dev/docs",
       "label": "Edit This Page"
     },
     "github": {


### PR DESCRIPTION
Change the branch for edit from `master` to `dev` as docs are built from `dev` branch now.