### PR TITLE
Add missing repository key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Evan You",
   "license": "MIT",
   "main": "dist/vue-router.common.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vuejs/vue-router.git"
+  },
   "typings": "types/index.d.ts",
   "files": [
     "dist/vue-router.js",


### PR DESCRIPTION
This PR resolves the missing repository key that should be present in the package.json to direct users to the repository when using utilities such as `npm-check` or `yarn upgrade-interactive`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
