### PR TITLE
Props option usage with named views (solve #1183)

### DIFF
--- a/docs/en/essentials/passing-props.md
+++ b/docs/en/essentials/passing-props.md
@@ -27,6 +27,13 @@ const User = {
 const router = new VueRouter({
   routes: [
     { path: '/user/:id', component: User, props: true }
+    
+    // for routes with named views, you have to define the props option for each named view:
+    {
+      path: '/user/:id', 
+      components: { default: User, sidebar: Sidebar },
+      props: {user: true, sidebar: true }
+    }
   ]
 })
 ```

--- a/docs/en/essentials/passing-props.md
+++ b/docs/en/essentials/passing-props.md
@@ -32,7 +32,7 @@ const router = new VueRouter({
     {
       path: '/user/:id', 
       components: { default: User, sidebar: Sidebar },
-      props: {default: true, sidebar: true }
+      props: {default: true, sidebar: false }
     }
   ]
 })

--- a/docs/en/essentials/passing-props.md
+++ b/docs/en/essentials/passing-props.md
@@ -32,7 +32,7 @@ const router = new VueRouter({
     {
       path: '/user/:id', 
       components: { default: User, sidebar: Sidebar },
-      props: {user: true, sidebar: true }
+      props: {default: true, sidebar: true }
     }
   ]
 })

--- a/docs/en/essentials/passing-props.md
+++ b/docs/en/essentials/passing-props.md
@@ -32,7 +32,7 @@ const router = new VueRouter({
     {
       path: '/user/:id', 
       components: { default: User, sidebar: Sidebar },
-      props: {default: true, sidebar: false }
+      props: { default: true, sidebar: false }
     }
   ]
 })


### PR DESCRIPTION
The `props` option in route configurations works a bit differently for routes that have multiple components for named routes.

I added a description of this differing API to the docs.
