### PR TITLE
Fix params passed to `scrollHandler` (fix #1207)

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -30,17 +30,19 @@ export class HTML5History extends History {
   }
 
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
+    const { current: fromRoute } = this
     this.transitionTo(location, route => {
       pushState(cleanPath(this.base + route.fullPath))
-      handleScroll(this.router, route, this.current, false)
+      handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)
   }
 
   replace (location: RawLocation, onComplete?: Function, onAbort?: Function) {
+    const { current: fromRoute } = this
     this.transitionTo(location, route => {
       replaceState(cleanPath(this.base + route.fullPath))
-      handleScroll(this.router, route, this.current, false)
+      handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)
   }


### PR DESCRIPTION
Currently `from` is always equal to `to` for `scrollHandler(to, from, savedPosition)`.
Should capture `this.current`(the `from` route) before making the transition to fix this.