### PR TITLE
Case Sensitive Option for Routes #1214

### DIFF
--- a/examples/redirect/app.js
+++ b/examples/redirect/app.js
@@ -9,6 +9,8 @@ const Foo = { template: '<div>foo</div>' }
 const Bar = { template: '<div>bar</div>' }
 const Baz = { template: '<div>baz</div>' }
 const WithParams = { template: '<div>{{ $route.params.id }}</div>' }
+const Foobar = { template: '<div>foobar</div>' }
+const FooBar = { template: '<div>FooBar</div>' }
 
 const router = new VueRouter({
   mode: 'history',
@@ -51,10 +53,10 @@ const router = new VueRouter({
     { path: '/redirect-with-params/:id', redirect: '/with-params/:id' },
 
     // redirect with caseSensitive
-    { path: '/foobar', redirect: '/FooBar', caseSensitive: true },
+    { path: '/foobar', component: Foobar, caseSensitive: true },
 
     // redirect with pathToRegexpOptions
-    { path: '/FooBar', redirect: '/FOOBAR', pathToRegexpOptions: { sensitive: true }},
+    { path: '/FooBar', component: FooBar, pathToRegexpOptions: { sensitive: true }},
 
     // catch all redirect
     { path: '*', redirect: '/' }
@@ -102,13 +104,13 @@ new Vue({
         <li><router-link to="/redirect-with-params/123">
           /redirect-with-params/123 (redirects to /with-params/123)
         </router-link></li>
-        
+
         <li><router-link to="/foobar">
-          /foobar (redirects to /FooBar)
+          /foobar
         </router-link></li>
-        
+
         <li><router-link to="/FooBar">
-          /FooBar (redirects to /FOOBAR)
+          /FooBar
         </router-link></li>
 
         <li><router-link to="/not-found">

--- a/examples/redirect/app.js
+++ b/examples/redirect/app.js
@@ -54,7 +54,7 @@ const router = new VueRouter({
     { path: '/foobar', redirect: '/FooBar', caseSensitive: true },
 
     // redirect with pathToRegexpOptions
-    { path: '/FooBar', redirect: '/bar', pathToRegexpOptions: { sensitive: true }},
+    { path: '/FooBar', redirect: '/FOOBAR', pathToRegexpOptions: { sensitive: true }},
 
     // catch all redirect
     { path: '*', redirect: '/' }

--- a/examples/redirect/app.js
+++ b/examples/redirect/app.js
@@ -108,7 +108,7 @@ new Vue({
         </router-link></li>
         
         <li><router-link to="/FooBar">
-          /FooBar (redirects to /bar)
+          /FooBar (redirects to /FOOBAR)
         </router-link></li>
 
         <li><router-link to="/not-found">

--- a/examples/redirect/app.js
+++ b/examples/redirect/app.js
@@ -50,6 +50,12 @@ const router = new VueRouter({
     // redirect with params
     { path: '/redirect-with-params/:id', redirect: '/with-params/:id' },
 
+    // redirect with caseSensitive
+    { path: '/foobar', redirect: '/FooBar', caseSensitive: true },
+
+    // redirect with pathToRegexpOptions
+    { path: '/FooBar', redirect: '/bar', pathToRegexpOptions: { sensitive: true }},
+
     // catch all redirect
     { path: '*', redirect: '/' }
   ]
@@ -95,6 +101,14 @@ new Vue({
 
         <li><router-link to="/redirect-with-params/123">
           /redirect-with-params/123 (redirects to /with-params/123)
+        </router-link></li>
+        
+        <li><router-link to="/foobar">
+          /foobar (redirects to /FooBar)
+        </router-link></li>
+        
+        <li><router-link to="/FooBar">
+          /FooBar (redirects to /bar)
         </router-link></li>
 
         <li><router-link to="/not-found">

--- a/examples/route-matching/app.js
+++ b/examples/route-matching/app.js
@@ -21,7 +21,14 @@ const router = new VueRouter({
     // asterisk can match anything
     { path: '/asterisk/*' },
     // make part of the path optional by wrapping with parens and add "?"
-    { path: '/optional-group/(foo/)?bar' }
+    { path: '/optional-group/(foo/)?bar' },
+
+    // caseSensitive match
+    { path: '/FooBar', caseSensitive: true },
+    { path: '/FOOBar', pathToRegexpOptions: { sensitive: true }},
+    // Not case sensitive (which is default)
+    { path: '/foo', caseSensitive: false },
+    { path: '/FOO', caseSensitive: false } // Should match /foo
   ]
 })
 
@@ -41,6 +48,10 @@ new Vue({
         <li><router-link to="/asterisk/foo/bar">/asterisk/foo/bar</router-link></li>
         <li><router-link to="/optional-group/bar">/optional-group/bar</router-link></li>
         <li><router-link to="/optional-group/foo/bar">/optional-group/foo/bar</router-link></li>
+        <li><router-link to="/FooBar">/FooBar</router-link></li>
+        <li><router-link to="/FOOBar">/FOOBar</router-link></li>
+        <li><router-link to="/foo">/foo</router-link></li>
+        <li><router-link to="/FOO">/FOO</router-link></li>
       </ul>
       <p>Route context</p>
       <pre>{{ JSON.stringify($route, null, 2) }}</pre>

--- a/examples/route-matching/app.js
+++ b/examples/route-matching/app.js
@@ -21,14 +21,7 @@ const router = new VueRouter({
     // asterisk can match anything
     { path: '/asterisk/*' },
     // make part of the path optional by wrapping with parens and add "?"
-    { path: '/optional-group/(foo/)?bar' },
-
-    // caseSensitive match
-    { path: '/FooBar', caseSensitive: true },
-    { path: '/FOOBar', pathToRegexpOptions: { sensitive: true }},
-    // Not case sensitive (which is default)
-    { path: '/foo', caseSensitive: false },
-    { path: '/FOO', caseSensitive: false } // Should match /foo
+    { path: '/optional-group/(foo/)?bar' }
   ]
 })
 
@@ -48,10 +41,6 @@ new Vue({
         <li><router-link to="/asterisk/foo/bar">/asterisk/foo/bar</router-link></li>
         <li><router-link to="/optional-group/bar">/optional-group/bar</router-link></li>
         <li><router-link to="/optional-group/foo/bar">/optional-group/foo/bar</router-link></li>
-        <li><router-link to="/FooBar">/FooBar</router-link></li>
-        <li><router-link to="/FOOBar">/FOOBar</router-link></li>
-        <li><router-link to="/foo">/foo</router-link></li>
-        <li><router-link to="/FOO">/FOO</router-link></li>
       </ul>
       <p>Route context</p>
       <pre>{{ JSON.stringify($route, null, 2) }}</pre>

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -6,7 +6,7 @@ declare class RouteRegExp extends RegExp {
 
 declare module 'path-to-regexp' {
   declare var exports: {
-    (path: string, keys?: Array<?{ name: string }>): RouteRegExp;
+    (path: string, keys?: Array<?{ name: string }>, options?: Object): RouteRegExp;
     compile: (path: string) => (params: Object) => string;
   }
 }

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -37,6 +37,12 @@ declare type RouterOptions = {
 
 declare type RedirectOption = RawLocation | ((to: Route) => RawLocation)
 
+declare type PathToRegexpOptions = {
+  sensitive?: boolean,
+  strict?: boolean,
+  end?: boolean
+}
+
 declare type RouteConfig = {
   path: string;
   name?: string;
@@ -48,6 +54,8 @@ declare type RouteConfig = {
   beforeEnter?: NavigationGuard;
   meta?: any;
   props?: boolean | Object | Function;
+  caseSensitive?: boolean;
+  pathToRegexpOptions?: PathToRegexpOptions;
 }
 
 declare type RouteRecord = {
@@ -62,6 +70,7 @@ declare type RouteRecord = {
   beforeEnter: ?NavigationGuard;
   meta: any;
   props: boolean | Object | Function | Dictionary<boolean | Object | Function>;
+  pathToRegexpOptions: PathToRegexpOptions;
 }
 
 declare type Location = {

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -4,9 +4,15 @@ declare class RouteRegExp extends RegExp {
   keys: Array<{ name: string, optional: boolean }>;
 }
 
+declare type PathToRegexpOptions = {
+  sensitive?: boolean,
+  strict?: boolean,
+  end?: boolean
+}
+
 declare module 'path-to-regexp' {
   declare var exports: {
-    (path: string, keys?: Array<?{ name: string }>, options?: Object): RouteRegExp;
+    (path: string, keys?: Array<?{ name: string }>, options?: PathToRegexpOptions): RouteRegExp;
     compile: (path: string) => (params: Object) => string;
   }
 }
@@ -37,12 +43,6 @@ declare type RouterOptions = {
 
 declare type RedirectOption = RawLocation | ((to: Route) => RawLocation)
 
-declare type PathToRegexpOptions = {
-  sensitive?: boolean,
-  strict?: boolean,
-  end?: boolean
-}
-
 declare type RouteConfig = {
   path: string;
   name?: string;
@@ -70,7 +70,6 @@ declare type RouteRecord = {
   beforeEnter: ?NavigationGuard;
   meta: any;
   props: boolean | Object | Function | Dictionary<boolean | Object | Function>;
-  pathToRegexpOptions: PathToRegexpOptions;
 }
 
 declare type Location = {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -79,8 +79,7 @@ function addRouteRecord (
       ? {}
       : route.components
         ? route.props
-        : { default: route.props },
-    pathToRegexpOptions
+        : { default: route.props }
   }
 
   if (route.children) {
@@ -143,7 +142,6 @@ function addRouteRecord (
   }
 }
 
-// TODO add regex options
 function compileRouteRegex (path: string, pathToRegexpOptions: PathToRegexpOptions): RouteRegExp {
   const regex = Regexp(path, [], pathToRegexpOptions)
   if (process.env.NODE_ENV !== 'production') {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -66,8 +66,7 @@ function addRouteRecord (
 
   const record: RouteRecord = {
     path: normalizedPath,
-    // TODO pass pathToRegexpOptions
-    regex: compileRouteRegex(normalizedPath),
+    regex: compileRouteRegex(normalizedPath, pathToRegexpOptions),
     components: route.components || { default: route.component },
     instances: {},
     name,
@@ -145,8 +144,8 @@ function addRouteRecord (
 }
 
 // TODO add regex options
-function compileRouteRegex (path: string): RouteRegExp {
-  const regex = Regexp(path)
+function compileRouteRegex (path: string, pathToRegexpOptions: PathToRegexpOptions): RouteRegExp {
+  const regex = Regexp(path, [], pathToRegexpOptions)
   if (process.env.NODE_ENV !== 'production') {
     const keys: any = {}
     regex.keys.forEach(key => {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -58,8 +58,15 @@ function addRouteRecord (
   }
 
   const normalizedPath = normalizePath(path, parent)
+  const pathToRegexpOptions: PathToRegexpOptions = route.pathToRegexpOptions || {}
+
+  if (typeof route.caseSensitive === 'boolean') {
+    pathToRegexpOptions.sensitive = route.caseSensitive
+  }
+
   const record: RouteRecord = {
     path: normalizedPath,
+    // TODO pass pathToRegexpOptions
     regex: compileRouteRegex(normalizedPath),
     components: route.components || { default: route.component },
     instances: {},
@@ -73,7 +80,8 @@ function addRouteRecord (
       ? {}
       : route.components
         ? route.props
-        : { default: route.props }
+        : { default: route.props },
+    pathToRegexpOptions: pathToRegexpOptions
   }
 
   if (route.children) {
@@ -136,6 +144,7 @@ function addRouteRecord (
   }
 }
 
+// TODO add regex options
 function compileRouteRegex (path: string): RouteRegExp {
   const regex = Regexp(path)
   if (process.env.NODE_ENV !== 'production') {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -81,7 +81,7 @@ function addRouteRecord (
       : route.components
         ? route.props
         : { default: route.props },
-    pathToRegexpOptions: pathToRegexpOptions
+    pathToRegexpOptions
   }
 
   if (route.children) {

--- a/test/e2e/specs/redirect.js
+++ b/test/e2e/specs/redirect.js
@@ -3,7 +3,7 @@ module.exports = {
     browser
     .url('http://localhost:8080/redirect/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 10)
+      .assert.count('li a', 12)
       // assert correct href with base
       .assert.attributeContains('li:nth-child(1) a', 'href', '/redirect/relative-redirect')
       .assert.attributeContains('li:nth-child(2) a', 'href', '/redirect/relative-redirect?foo=bar')
@@ -14,7 +14,9 @@ module.exports = {
       .assert.attributeContains('li:nth-child(7) a', 'href', '/redirect/dynamic-redirect#baz')
       .assert.attributeContains('li:nth-child(8) a', 'href', '/redirect/named-redirect')
       .assert.attributeContains('li:nth-child(9) a', 'href', '/redirect/redirect-with-params/123')
-      .assert.attributeContains('li:nth-child(10) a', 'href', '/not-found')
+      .assert.attributeContains('li:nth-child(10) a', 'href', '/redirect/foobar')
+      .assert.attributeContains('li:nth-child(11) a', 'href', '/redirect/FooBar')
+      .assert.attributeContains('li:nth-child(12) a', 'href', '/not-found')
 
       .assert.containsText('.view', 'default')
 
@@ -55,6 +57,14 @@ module.exports = {
       .assert.containsText('.view', '123')
 
       .click('li:nth-child(10) a')
+      .assert.urlEquals('http://localhost:8080/redirect/')
+      .assert.containsText('.view', 'default')
+
+      .click('li:nth-child(11) a')
+      .assert.urlEquals('http://localhost:8080/redirect/')
+      .assert.containsText('.view', 'default')
+
+      .click('li:nth-child(12) a')
       .assert.urlEquals('http://localhost:8080/redirect/')
       .assert.containsText('.view', 'default')
 

--- a/test/e2e/specs/redirect.js
+++ b/test/e2e/specs/redirect.js
@@ -57,12 +57,12 @@ module.exports = {
       .assert.containsText('.view', '123')
 
       .click('li:nth-child(10) a')
-      .assert.urlEquals('http://localhost:8080/redirect/')
-      .assert.containsText('.view', 'default')
+      .assert.urlEquals('http://localhost:8080/redirect/foobar')
+      .assert.containsText('.view', 'foobar')
 
       .click('li:nth-child(11) a')
-      .assert.urlEquals('http://localhost:8080/redirect/')
-      .assert.containsText('.view', 'default')
+      .assert.urlEquals('http://localhost:8080/redirect/FooBar')
+      .assert.containsText('.view', 'FooBar')
 
       .click('li:nth-child(12) a')
       .assert.urlEquals('http://localhost:8080/redirect/')
@@ -113,6 +113,16 @@ module.exports = {
       .waitForElementVisible('#app', 1000)
       .assert.urlEquals('http://localhost:8080/redirect/with-params/123')
       .assert.containsText('.view', '123')
+
+    .url('http://localhost:8080/redirect/foobar')
+      .waitForElementVisible('#app', 1000)
+      .assert.urlEquals('http://localhost:8080/redirect/foobar')
+      .assert.containsText('.view', 'foobar')
+
+    .url('http://localhost:8080/redirect/FooBar')
+      .waitForElementVisible('#app', 1000)
+      .assert.urlEquals('http://localhost:8080/redirect/FooBar')
+      .assert.containsText('.view', 'FooBar')
 
     .url('http://localhost:8080/redirect/not-found')
       .waitForElementVisible('#app', 1000)

--- a/test/e2e/specs/route-matching.js
+++ b/test/e2e/specs/route-matching.js
@@ -3,7 +3,7 @@ module.exports = {
     browser
     .url('http://localhost:8080/route-matching/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 10)
+      .assert.count('li a', 14)
       .assert.evaluate(function () {
         var route = JSON.parse(document.querySelector('pre').textContent)
         return (
@@ -125,6 +125,53 @@ module.exports = {
         )
       }, null, '/optional-group/foo/bar')
 
+      .click('li:nth-child(11) a')
+      .assert.evaluate(function () {
+        var route = JSON.parse(document.querySelector('pre').textContent)
+        return (
+          route.matched.length === 1 &&
+          route.matched[0].path === '/FooBar' &&
+          route.fullPath === '/FooBar' &&
+          JSON.stringify(route.params) === JSON.stringify({}) &&
+          route.matched[0].pathToRegexpOptions.sensitive === true
+        )
+      }, null, '/FooBar')
+
+      .click('li:nth-child(12) a')
+      .assert.evaluate(function () {
+        var route = JSON.parse(document.querySelector('pre').textContent)
+        return (
+          route.matched.length === 1 &&
+          route.matched[0].path === '/FOOBar' &&
+          route.fullPath === '/FOOBar' &&
+          JSON.stringify(route.params) === JSON.stringify({}) &&
+          route.matched[0].pathToRegexpOptions.sensitive === true
+        )
+      }, null, '/FOOBar')
+
+      .click('li:nth-child(13) a')
+      .assert.evaluate(function () {
+        var route = JSON.parse(document.querySelector('pre').textContent)
+        return (
+          route.matched.length === 1 &&
+          route.matched[0].path === '/foo' &&
+          route.fullPath === '/foo' &&
+          JSON.stringify(route.params) === JSON.stringify({}) &&
+          route.matched[0].pathToRegexpOptions.sensitive === false
+        )
+      }, null, '/foo')
+
+      .click('li:nth-child(14) a')
+      .assert.evaluate(function () {
+        var route = JSON.parse(document.querySelector('pre').textContent)
+        return (
+          route.matched.length === 1 &&
+          route.matched[0].path === '/foo' &&
+          route.fullPath === '/FOO' &&
+          JSON.stringify(route.params) === JSON.stringify({}) &&
+          route.matched[0].pathToRegexpOptions.sensitive === false
+        )
+      }, null, '/FOOBar')
       .end()
   }
 }

--- a/test/e2e/specs/route-matching.js
+++ b/test/e2e/specs/route-matching.js
@@ -171,7 +171,7 @@ module.exports = {
           JSON.stringify(route.params) === JSON.stringify({}) &&
           route.matched[0].pathToRegexpOptions.sensitive === false
         )
-      }, null, '/FOOBar')
+      }, null, '/FOO')
       .end()
   }
 }

--- a/test/e2e/specs/route-matching.js
+++ b/test/e2e/specs/route-matching.js
@@ -3,7 +3,7 @@ module.exports = {
     browser
     .url('http://localhost:8080/route-matching/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 14)
+      .assert.count('li a', 10)
       .assert.evaluate(function () {
         var route = JSON.parse(document.querySelector('pre').textContent)
         return (
@@ -124,54 +124,6 @@ module.exports = {
           })
         )
       }, null, '/optional-group/foo/bar')
-
-      .click('li:nth-child(11) a')
-      .assert.evaluate(function () {
-        var route = JSON.parse(document.querySelector('pre').textContent)
-        return (
-          route.matched.length === 1 &&
-          route.matched[0].path === '/FooBar' &&
-          route.fullPath === '/FooBar' &&
-          JSON.stringify(route.params) === JSON.stringify({}) &&
-          route.matched[0].pathToRegexpOptions.sensitive === true
-        )
-      }, null, '/FooBar')
-
-      .click('li:nth-child(12) a')
-      .assert.evaluate(function () {
-        var route = JSON.parse(document.querySelector('pre').textContent)
-        return (
-          route.matched.length === 1 &&
-          route.matched[0].path === '/FOOBar' &&
-          route.fullPath === '/FOOBar' &&
-          JSON.stringify(route.params) === JSON.stringify({}) &&
-          route.matched[0].pathToRegexpOptions.sensitive === true
-        )
-      }, null, '/FOOBar')
-
-      .click('li:nth-child(13) a')
-      .assert.evaluate(function () {
-        var route = JSON.parse(document.querySelector('pre').textContent)
-        return (
-          route.matched.length === 1 &&
-          route.matched[0].path === '/foo' &&
-          route.fullPath === '/foo' &&
-          JSON.stringify(route.params) === JSON.stringify({}) &&
-          route.matched[0].pathToRegexpOptions.sensitive === false
-        )
-      }, null, '/foo')
-
-      .click('li:nth-child(14) a')
-      .assert.evaluate(function () {
-        var route = JSON.parse(document.querySelector('pre').textContent)
-        return (
-          route.matched.length === 1 &&
-          route.matched[0].path === '/foo' &&
-          route.fullPath === '/FOO' &&
-          JSON.stringify(route.params) === JSON.stringify({}) &&
-          route.matched[0].pathToRegexpOptions.sensitive === false
-        )
-      }, null, '/FOO')
       .end()
   }
 }

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -85,12 +85,52 @@ describe('Creating Route Map', function () {
       { path: '/foobar', name: 'foobar', component: Foobar, caseSensitive: true }
     ]
 
-    it('caseSensitive option in routes', function () {
+    it('caseSensitive option in route', function () {
       const { nameMap } = createRouteMap(routes)
 
       expect(nameMap.FooBar.regex.ignoreCase).toBe(false)
       expect(nameMap.bar.regex.ignoreCase).toBe(true)
       expect(nameMap.foo.regex.ignoreCase).toBe(true)
+    })
+
+    it('pathToRegexpOptions option in route', function () {
+      const { nameMap } = createRouteMap([
+        {
+          name: 'foo',
+          path: '/foo',
+          component: Foo,
+          pathToRegexpOptions: {
+            sensitive: true
+          }
+        },
+        {
+          name: 'bar',
+          path: '/bar',
+          component: Bar,
+          pathToRegexpOptions: {
+            sensitive: false
+          }
+        }
+      ])
+
+      expect(nameMap.foo.regex.ignoreCase).toBe(false)
+      expect(nameMap.bar.regex.ignoreCase).toBe(true)
+    })
+
+    it('caseSensitive over pathToRegexpOptions in route', function () {
+      const { nameMap } = createRouteMap([
+        {
+          name: 'foo',
+          path: '/foo',
+          component: Foo,
+          caseSensitive: true,
+          pathToRegexpOptions: {
+            sensitive: false
+          }
+        }
+      ])
+
+      expect(nameMap.foo.regex.ignoreCase).toBe(false)
     })
   })
 })

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -3,6 +3,8 @@ import { createRouteMap } from '../../../src/create-route-map'
 
 const Home = { template: '<div>This is Home</div>' }
 const Foo = { template: '<div>This is Foo</div>' }
+const FooBar = { template: '<div>This is FooBar</div>' }
+const Foobar = { template: '<div>This is foobar</div>' }
 const Bar = { template: '<div>This is Bar <router-view></router-view></div>' }
 const Baz = { template: '<div>This is Baz</div>' }
 
@@ -73,5 +75,22 @@ describe('Creating Route Map', function () {
     ])
     expect(console.warn).toHaveBeenCalled()
     expect(console.warn.calls.argsFor(0)[0]).toMatch('vue-router] Duplicate param keys in route with path: "/foo/:id/bar/:id"')
+  })
+
+  describe('path-to-regexp options', function () {
+    const routes = [
+      { path: '/foo', name: 'foo', component: Foo },
+      { path: '/bar', name: 'bar', component: Bar, caseSensitive: false },
+      { path: '/FooBar', name: 'FooBar', component: FooBar, caseSensitive: true },
+      { path: '/foobar', name: 'foobar', component: Foobar, caseSensitive: true }
+    ]
+
+    it('caseSensitive option in routes', function () {
+      const { nameMap } = createRouteMap(routes)
+
+      expect(nameMap.FooBar.regex.ignoreCase).toBe(false)
+      expect(nameMap.bar.regex.ignoreCase).toBe(true)
+      expect(nameMap.foo.regex.ignoreCase).toBe(true)
+    })
   })
 })

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -60,6 +60,12 @@ export interface RouterOptions {
 
 type RoutePropsFunction = (route: Route) => Object;
 
+export interface PathToRegexpOptions {
+  sensitive?: boolean;
+  strict?: boolean;
+  end?: boolean;
+}
+
 export interface RouteConfig {
   path: string;
   name?: string;
@@ -71,6 +77,8 @@ export interface RouteConfig {
   meta?: any;
   beforeEnter?: NavigationGuard;
   props?: boolean | Object | RoutePropsFunction;
+  caseSensitive?: boolean;
+  pathToRegexpOptions?: PathToRegexpOptions;
 }
 
 export interface RouteRecord {


### PR DESCRIPTION
Added both a `caseSenstive` and `pathToRegexpOptions` property on RouteConfig.  The `caseSensitive` property will override and add to `pathToRegexpOptions` which defaults to `{}`. 

Along with that `RouteRecord` gets `pathToRegexpOptions` that comes from `RouteConfig`