### PR TITLE
Update navigation.md

### DIFF
--- a/docs/en/essentials/navigation.md
+++ b/docs/en/essentials/navigation.md
@@ -15,7 +15,7 @@ This is the method called internally when you click a `<router-link>`, so clicki
 The argument can be a string path, or a location descriptor object. Examples:
 
 ``` js
-// literal string
+// literal string path
 router.push('home')
 
 // object


### PR DESCRIPTION
The sentence above the changed text mentions that the string represents the path. But I think `literal string path` will be much clearer because not everyone wants to read the text. So it's instantly recognizeable that if you just pass a simple string it's a path and not the route name.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
