### PR TITLE
fix target _blank when anchor has children

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -82,7 +82,12 @@ export default {
     return h(this.tag, data, this.$slots.default)
   }
 }
-
+// return first anchor parent of element
+function getAnchorParent (event) {
+  return event.path.find(parent => {
+    return parent.localName === 'a'
+  })
+}
 function guardEvent (e) {
   // don't redirect with control keys
   if (e.metaKey || e.ctrlKey || e.shiftKey) return
@@ -91,8 +96,16 @@ function guardEvent (e) {
   // don't redirect on right click
   if (e.button !== undefined && e.button !== 0) return
   // don't redirect if `target="_blank"`
+
   if (e.target && e.target.getAttribute) {
-    const target = e.target.getAttribute('target')
+    let target
+    // check if anchor tag
+    if (e.target.localName === 'a') {
+      target = e.target.getAttribute('target')
+    } else {
+      // get anchor parent of element and assign target attribute
+      target = getAnchorParent(e).getAttribute('target')
+    }
     if (/\b_blank\b/i.test(target)) return
   }
   // this may be a Weex event which doesn't have this method

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -82,12 +82,7 @@ export default {
     return h(this.tag, data, this.$slots.default)
   }
 }
-// return first anchor parent of element
-function getAnchorParent (event) {
-  return event.path.find(parent => {
-    return parent.localName === 'a'
-  })
-}
+
 function guardEvent (e) {
   // don't redirect with control keys
   if (e.metaKey || e.ctrlKey || e.shiftKey) return
@@ -96,16 +91,8 @@ function guardEvent (e) {
   // don't redirect on right click
   if (e.button !== undefined && e.button !== 0) return
   // don't redirect if `target="_blank"`
-
   if (e.target && e.target.getAttribute) {
-    let target
-    // check if anchor tag
-    if (e.target.localName === 'a') {
-      target = e.target.getAttribute('target')
-    } else {
-      // get anchor parent of element and assign target attribute
-      target = getAnchorParent(e).getAttribute('target')
-    }
+    const target = e.currentTarget.getAttribute('target')
     if (/\b_blank\b/i.test(target)) return
   }
   // this may be a Weex event which doesn't have this method

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -91,7 +91,7 @@ function guardEvent (e) {
   // don't redirect on right click
   if (e.button !== undefined && e.button !== 0) return
   // don't redirect if `target="_blank"`
-  if (e.target && e.target.getAttribute) {
+  if (e.currentTarget && e.currentTarget.getAttribute) {
     const target = e.currentTarget.getAttribute('target')
     if (/\b_blank\b/i.test(target)) return
   }


### PR DESCRIPTION
Couple of days ago, we have faced an issue with out non-SPA project:
Once you add a child element to a ``<router-link>`` with ``target="_blank"`` attribute, it wouldn't fire on a new tab. check this fiddle:
https://jsfiddle.net/asynchronous/dnLs1dm4/10/

I've changed ``gaurdEvent`` method in ``link`` component so it could fix this issue.


