### PR TITLE
make a copy when query param value is an array (fix #1182)

### DIFF
--- a/src/util/query.js
+++ b/src/util/query.js
@@ -19,21 +19,18 @@ export function resolveQuery (
   query: ?string,
   extraQuery: Dictionary<string> = {}
 ): Dictionary<string> {
-  if (query) {
-    let parsedQuery
-    try {
-      parsedQuery = parseQuery(query)
-    } catch (e) {
-      process.env.NODE_ENV !== 'production' && warn(false, e.message)
-      parsedQuery = {}
-    }
-    for (const key in extraQuery) {
-      parsedQuery[key] = extraQuery[key]
-    }
-    return parsedQuery
-  } else {
-    return extraQuery
+  let parsedQuery
+  try {
+    parsedQuery = parseQuery(query)
+  } catch (e) {
+    process.env.NODE_ENV !== 'production' && warn(false, e.message)
+    parsedQuery = {}
   }
+  for (const key in extraQuery) {
+    const val = extraQuery[key]
+    parsedQuery[key] = Array.isArray(val) ? val.slice() : val
+  }
+  return parsedQuery
 }
 
 function parseQuery (query: string): Dictionary<string> {

--- a/src/util/query.js
+++ b/src/util/query.js
@@ -21,7 +21,7 @@ export function resolveQuery (
 ): Dictionary<string> {
   let parsedQuery
   try {
-    parsedQuery = parseQuery(query)
+    parsedQuery = parseQuery(query || '')
   } catch (e) {
     process.env.NODE_ENV !== 'production' && warn(false, e.message)
     parsedQuery = {}

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -9,6 +9,15 @@ describe('Query utils', () => {
         baz: 'qux'
       }))
     })
+
+    it('should make a copy when param value is an array', () => {
+      const arr = ['bar']
+      const query = resolveQuery('', { foo: arr })
+      arr.push('baz')
+      expect(JSON.stringify(query)).toBe(JSON.stringify({
+        foo: ['bar']
+      }))
+    })
   })
 
   describe('stringifyQuery', () => {


### PR DESCRIPTION
fix #1182 
Don't using the object reference as query value directly.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
