### PR TITLE
Fix nested query parser follow issue #1268

### DIFF
--- a/examples/active-links/app.js
+++ b/examples/active-links/app.js
@@ -60,7 +60,11 @@ new Vue({
             /users/evan?foo=bar&baz=qux
           </router-link>
         </li>
-
+        <li>
+          <router-link :to="{ path: '/users/evan', query: { quux: { corge: 'grault' }}}">
+            /active-links/users/evan?quux[corge]=grault
+          </router-link>
+        </li>
         <li><router-link to="/about">/about</router-link></li>
 
         <router-link tag="li" to="/about">

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -9,7 +9,8 @@ declare module 'path-to-regexp' {
 
 declare module 'qs' {
   declare var exports: {
-    stringify(obj: Dictionary<any>, option: Dictionary<any>): string
+    stringify(obj: Dictionary<any>, option: Dictionary<any>): string,
+    parse(query: string): Dictionary<any>
   }
 }
 

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -7,6 +7,12 @@ declare module 'path-to-regexp' {
   }
 }
 
+declare module 'qs' {
+  declare var exports: {
+    stringify(obj: Dictionary<any>, option: Dictionary<any>): string
+  }
+}
+
 declare type Dictionary<T> = { [key: string]: T }
 
 declare type NavigationGuard = (

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "vue-loader": "^11.0.0",
     "vue-template-compiler": "^2.1.0",
     "webpack": "^2.2.0",
-    "webpack-dev-middleware": "^1.9.0"
+    "webpack-dev-middleware": "^1.9.0",
+    "qs": "^6.4.0"
   }
 }

--- a/src/util/query.js
+++ b/src/util/query.js
@@ -14,8 +14,6 @@ const encode = str => encodeURIComponent(str)
   .replace(encodeReserveRE, encodeReserveReplacer)
   .replace(commaRE, ',')
 
-const decode = decodeURIComponent
-
 export function resolveQuery (
   query: ?string,
   extraQuery: Dictionary<string> = {}
@@ -37,63 +35,12 @@ export function resolveQuery (
   }
 }
 
-function parseQuery (query: string): Dictionary<string> {
-  const res = {}
-
-  query = query.trim().replace(/^(\?|#|&)/, '')
-
-  if (!query) {
-    return res
-  }
-
-  query.split('&').forEach(param => {
-    const parts = param.replace(/\+/g, ' ').split('=')
-    const key = decode(parts.shift())
-    const val = parts.length > 0
-      ? decode(parts.join('='))
-      : null
-
-    if (res[key] === undefined) {
-      res[key] = val
-    } else if (Array.isArray(res[key])) {
-      res[key].push(val)
-    } else {
-      res[key] = [res[key], val]
-    }
-  })
-
+export function parseQuery (query: string): Dictionary<string> {
+  const res = qs.parse(query)
   return res
 }
 
 export function stringifyQuery (obj: Dictionary<string>): string {
-  // const res = obj ? Object.keys(obj).map(key => {
-  //   const val = obj[key]
-
-  //   if (val === undefined) {
-  //     return ''
-  //   }
-
-  //   if (val === null) {
-  //     return encode(key)
-  //   }
-
-  //   if (Array.isArray(val)) {
-  //     const result = []
-  //     val.slice().forEach(val2 => {
-  //       if (val2 === undefined) {
-  //         return
-  //       }
-  //       if (val2 === null) {
-  //         result.push(encode(key))
-  //       } else {
-  //         result.push(encode(key) + '=' + encode(val2))
-  //       }
-  //     })
-  //     return result.join('&')
-  //   }
-
-  //   return encode(key) + '=' + encode(val)
-  // }).filter(x => x.length > 0).join('&') : null
   const res = obj ? qs.stringify(obj, { indices: false, encoder: function (str) {
     return encode(str)
   } }) : null

--- a/src/util/query.js
+++ b/src/util/query.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { warn } from './warn'
+import qs from 'qs'
 
 const encodeReserveRE = /[!'()*]/g
 const encodeReserveReplacer = c => '%' + c.charCodeAt(0).toString(16)
@@ -65,33 +66,36 @@ function parseQuery (query: string): Dictionary<string> {
 }
 
 export function stringifyQuery (obj: Dictionary<string>): string {
-  const res = obj ? Object.keys(obj).map(key => {
-    const val = obj[key]
+  // const res = obj ? Object.keys(obj).map(key => {
+  //   const val = obj[key]
 
-    if (val === undefined) {
-      return ''
-    }
+  //   if (val === undefined) {
+  //     return ''
+  //   }
 
-    if (val === null) {
-      return encode(key)
-    }
+  //   if (val === null) {
+  //     return encode(key)
+  //   }
 
-    if (Array.isArray(val)) {
-      const result = []
-      val.slice().forEach(val2 => {
-        if (val2 === undefined) {
-          return
-        }
-        if (val2 === null) {
-          result.push(encode(key))
-        } else {
-          result.push(encode(key) + '=' + encode(val2))
-        }
-      })
-      return result.join('&')
-    }
+  //   if (Array.isArray(val)) {
+  //     const result = []
+  //     val.slice().forEach(val2 => {
+  //       if (val2 === undefined) {
+  //         return
+  //       }
+  //       if (val2 === null) {
+  //         result.push(encode(key))
+  //       } else {
+  //         result.push(encode(key) + '=' + encode(val2))
+  //       }
+  //     })
+  //     return result.join('&')
+  //   }
 
-    return encode(key) + '=' + encode(val)
-  }).filter(x => x.length > 0).join('&') : null
+  //   return encode(key) + '=' + encode(val)
+  // }).filter(x => x.length > 0).join('&') : null
+  const res = obj ? qs.stringify(obj, { indices: false, encoder: function (str) {
+    return encode(str)
+  } }) : null
   return res ? `?${res}` : ''
 }

--- a/test/e2e/specs/active-links.js
+++ b/test/e2e/specs/active-links.js
@@ -4,7 +4,7 @@ module.exports = {
     browser
     .url('http://localhost:8080/active-links/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 11)
+      .assert.count('li a', 12)
       // assert correct href with base
       .assert.attributeContains('li:nth-child(1) a', 'href', '/active-links/')
       .assert.attributeContains('li:nth-child(2) a', 'href', '/active-links/')
@@ -15,8 +15,9 @@ module.exports = {
       .assert.attributeContains('li:nth-child(7) a', 'href', '/active-links/users/evan?foo=bar')
       .assert.attributeContains('li:nth-child(8) a', 'href', '/active-links/users/evan?foo=bar')
       .assert.attributeContains('li:nth-child(9) a', 'href', '/active-links/users/evan?foo=bar&baz=qux')
-      .assert.attributeContains('li:nth-child(10) a', 'href', '/active-links/about')
+      .assert.attributeContains('li:nth-child(10) a', 'href', '/active-links/users/evan?quux%5Bcorge%5D=grault')
       .assert.attributeContains('li:nth-child(11) a', 'href', '/active-links/about')
+      .assert.attributeContains('li:nth-child(12) a', 'href', '/active-links/about')
       .assert.containsText('.view', 'Home')
 
     assertActiveLinks(1, [1, 2])
@@ -28,9 +29,10 @@ module.exports = {
     assertActiveLinks(7, [1, 3, 5, 7, 8])
     assertActiveLinks(8, [1, 3, 5, 7, 8])
     assertActiveLinks(9, [1, 3, 5, 7, 9])
-    assertActiveLinks(10, [1, 10], [11])
-    assertActiveLinks(11, [1, 10], [11])
-
+    assertActiveLinks(10, [1, 3, 10])
+    assertActiveLinks(11, [1, 11], [12])
+    assertActiveLinks(12, [1, 11], [12])
+    
     browser.end()
 
     function assertActiveLinks (n, activeA, activeLI) {

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -1,4 +1,4 @@
-import { resolveQuery, stringifyQuery } from '../../../src/util/query'
+import { resolveQuery, stringifyQuery, parseQuery } from '../../../src/util/query'
 
 describe('Query utils', () => {
   describe('resolveQuery', () => {
@@ -18,6 +18,12 @@ describe('Query utils', () => {
         baz: 'qux',
         arr: [1, 2]
       })).toBe('?foo=bar&baz=qux&arr=1&arr=2')
+
+      expect(stringifyQuery({
+        foo: 'bar',
+        quux: { corge: 'grault' },
+        arr: [1, 2]
+      })).toBe('?foo=bar&quux%5Bcorge%5D=grault&arr=1&arr=2')
     })
 
     it('should escape reserved chars', () => {
@@ -30,6 +36,34 @@ describe('Query utils', () => {
       expect(stringifyQuery({
         list: '1,2,3'
       })).toBe('?list=1,2,3')
+    })
+  })
+
+  describe('parseQuery', () => {
+    it('should work', () => {
+      expect(parseQuery('?foo=bar&baz=qux&arr=1&arr=2')).toBe({
+        foo: 'bar',
+        baz: 'qux',
+        arr: [1, 2]
+      })
+
+      expect(parseQuery('?foo=bar&quux%5Bcorge%5D=grault&arr=1&arr=2')).toBe({
+        foo: 'bar',
+        quux: { corge: 'grault' },
+        arr: [1, 2]
+      })
+    })
+
+    it('should escape reserved chars', () => {
+      expect(parseQuery('?a=%2a%28%29%21')).toBe({
+        a: '*()!'
+      })
+    })
+
+    it('should preserve commas', () => {
+      expect(parseQuery('?list=1,2,3')).toBe({
+        list: '1,2,3'
+      })
     })
   })
 })

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -3,10 +3,12 @@ import { resolveQuery, stringifyQuery, parseQuery } from '../../../src/util/quer
 describe('Query utils', () => {
   describe('resolveQuery', () => {
     it('should work', () => {
-      const query = resolveQuery('foo=bar&foo=k', { baz: 'qux' })
+      const query = resolveQuery('foo=bar&foo=k', { baz: 'qux', quux: { corge: 'grault' }, arr: [1, 2] })
       expect(JSON.stringify(query)).toBe(JSON.stringify({
         foo: ['bar', 'k'],
-        baz: 'qux'
+        baz: 'qux',
+        quux: { corge: 'grault' },
+        arr: [1, 2]
       }))
     })
   })
@@ -36,34 +38,6 @@ describe('Query utils', () => {
       expect(stringifyQuery({
         list: '1,2,3'
       })).toBe('?list=1,2,3')
-    })
-  })
-
-  describe('parseQuery', () => {
-    it('should work', () => {
-      expect(parseQuery('?foo=bar&baz=qux&arr=1&arr=2')).toBe({
-        foo: 'bar',
-        baz: 'qux',
-        arr: [1, 2]
-      })
-
-      expect(parseQuery('?foo=bar&quux%5Bcorge%5D=grault&arr=1&arr=2')).toBe({
-        foo: 'bar',
-        quux: { corge: 'grault' },
-        arr: [1, 2]
-      })
-    })
-
-    it('should escape reserved chars', () => {
-      expect(parseQuery('?a=%2a%28%29%21')).toBe({
-        a: '*()!'
-      })
-    })
-
-    it('should preserve commas', () => {
-      expect(parseQuery('?list=1,2,3')).toBe({
-        list: '1,2,3'
-      })
     })
   })
 })

--- a/test/unit/specs/route.spec.js
+++ b/test/unit/specs/route.spec.js
@@ -54,12 +54,14 @@ describe('Route utils', () => {
     })
 
     it('with query', () => {
-      const a = { path: '/a/b', query: { foo: 'bar', baz: 'qux' }}
+      const a = { path: '/a/b', query: { foo: 'bar', baz: 'qux', quux: { corge: 1 }}}
       const b = { path: '/a', query: {}}
       const c = { path: '/a', query: { foo: 'bar' }}
       const d = { path: '/a', query: { foo: 'bar', a: 'b' }}
+      const e = { path: '/a', query: { quux: { corge: 1 }}}
       expect(isIncludedRoute(a, b)).toBe(true)
       expect(isIncludedRoute(a, c)).toBe(true)
+      expect(isIncludedRoute(a, e)).toBe(true)
       expect(isIncludedRoute(a, d)).toBe(false)
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,6 +3789,10 @@ qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
+qs@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
 qs@~6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.1.tgz#918c0b3bcd36679772baf135b1acb4c1651ed79d"
@@ -4199,13 +4203,13 @@ selenium-server@^2.53.1:
   version "2.53.1"
   resolved "https://registry.yarnpkg.com/selenium-server/-/selenium-server-2.53.1.tgz#d681528812f3c2e0531a6b7e613e23bb02cce8a6"
 
-"semver@2 || 3 || 4 || 5", semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
-
-semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@~5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
 send@0.14.2:
   version "0.14.2"


### PR DESCRIPTION
Normally when user pass query to push method like this

`this.$router.push({ query: { order: { name: 'asc' } } })`

Vue router will convert to 

`?order=[object Object]`

Instead of 

`?order[name]=asc`

I changed query parser for custom script to 'qs' module that support this use case

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
