### PR TITLE
Allow using `base` option with hash under history mode

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -61,6 +61,16 @@ export class HTML5History extends History {
 
 export function getLocation (base: string): string {
   let path = window.location.pathname
+
+  // Special handling for cases where base contains hash ('#')
+  if (base && base.indexOf('#') > -1) {
+    path = window.location.href
+    if (path.indexOf(base) === 0) {
+      // Leave the rest of the url as-is
+      return (path.slice(base.length) || '/')
+    }
+  }
+
   if (base && path.indexOf(base) === 0) {
     path = path.slice(base.length)
   }

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -64,7 +64,7 @@ export function getLocation (base: string): string {
 
   // Special handling for cases where base contains hash ('#')
   if (base && base.indexOf('#') > -1) {
-    path = window.location.href
+    path = window.location.href.replace(window.location.origin, '')
     if (path.indexOf(base) === 0) {
       // Leave the rest of the url as-is
       return (path.slice(base.length) || '/')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I'm not sure if using '#' inside base is a valid usage, though it currently works (in history mode, with an issue fixed by this PR), so I don't know whether it's a fix or a feature...

So the use case is:
1. Using vue-router in a hybrid app, where it's loaded as under `file://` scheme.
2. I want to keep using history mode so `scrollBehavior` can be used. (to deliver a native-like experience without manually adding code to track/restore scroll position)

It may seem crazy, but let me explain:

- Normally history mode won't work under `file://` scheme

  e.g. `file://path/to/index.html` + history mode + route '/foo' = `file://path/to/index.html/foo`, 404!

- But if we add a hash inside `base`, almost everything works (history API, popstate, etc).

  e.g. `file://path/to/index.html`, we use `base: 'file://path/to/index.html#'` (`location.pathname + '#'`) and trick the browser into thinking it's a hash route.

- The only issue is: when using `router.back()`, the route gets parsed as hash, resulting in a non-matched route. (due to the current way vue-router parses location inside `getLocation` using location.hash)

  e.g. `file://path/to/index.html#/foo` => `file://path/to/index.html#/bar` , then use `router.back()`(or history.go(-1)), the router now parses the location as `{path: '/path/to/index.html', hash: '#/foo'}`


This can be considered some kind of a `semi-hash` mode that utilizes history API while using a hash route.
This way we allow hybrid apps using `file://` scheme to enjoy history mode without being limited to hash mode.

//
Side notes:
- It's actually been used in my production app for months, with this little flaw worked-around with a catch-all redirect. Tested under iOS 9/10, Chrome(Crosswalk)
- `popstate` and `hashchange` are both fired when navigating.
