### PR TITLE
add router-link prop: `exact-active-class` & router option: `linkExactActiveClass`

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -22,6 +22,7 @@ export default {
     append: Boolean,
     replace: Boolean,
     activeClass: String,
+    exactActiveClass: String,
     event: {
       type: eventTypes,
       default: 'click'
@@ -34,19 +35,27 @@ export default {
 
     const classes = {}
     const globalActiveClass = router.options.linkActiveClass
+    const globalExactActiveClass = router.options.linkExactActiveClass
     // Support global empty active class
     const activeClassFallback = globalActiveClass == null
             ? 'router-link-active'
             : globalActiveClass
+    const exactActiveClassFallback = globalExactActiveClass == null
+            ? 'router-link-exact-active'
+            : globalExactActiveClass
     const activeClass = this.activeClass == null
             ? activeClassFallback
             : this.activeClass
+    const exactActiveClass = this.exactActiveClass == null
+            ? exactActiveClassFallback
+            : this.exactActiveClass
     const compareTarget = location.path
       ? createRoute(null, location, null, router)
       : route
 
+    classes[exactActiveClass] = isSameRoute(current, compareTarget)
     classes[activeClass] = this.exact
-      ? isSameRoute(current, compareTarget)
+      ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
 
     const handler = e => {


### PR DESCRIPTION
see issue #1360
we can use both `active-class` and `exact-active-class` at the same time now.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
