### PR TITLE
Fix hash-mode replaceHash() when page has a <base href />

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -92,8 +92,6 @@ function pushHash (path) {
 function replaceHash (path) {
   const href = window.location.href
   const i = href.indexOf('#')
-
-  window.location.replace(
-    window.location.href.slice(0, i >= 0 ? i : href.length) + '#' + path
-  )
+  const base = i >= 0 ? href.slice(0, i) : href
+  window.location.replace(`${base}#${path}`)
 }

--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -90,8 +90,10 @@ function pushHash (path) {
 }
 
 function replaceHash (path) {
-  const i = window.location.href.indexOf('#')
+  const href = window.location.href
+  const i = href.indexOf('#')
+
   window.location.replace(
-    window.location.href.slice(0, i >= 0 ? i : 0) + '#' + path
+    window.location.href.slice(0, i >= 0 ? i : href.length) + '#' + path
   )
 }


### PR DESCRIPTION
This PR attempts to fix a bug on pages that have HTML base tag.

## Reproduce
Edit `./examples/hash-mode/index.html` and insert something like this:

```diff
  <!DOCTYPE html>
+ <base href="/" />
  <link rel="stylesheet" href="/global.css">
  <a href="/">&larr; Examples index</a>
  <div id="app"></div>
  <script src="/__build__/shared.js"></script>
  <script src="/__build__/hash-mode.js"></script>
```

`node examples/server.js` then open http://localhost:8080/hash-mode/.

### Expect
`window.location` got replaced into `http://localhost:8080/hash-mode/#/`.

### Actual
Browser is redirected to `http://localhost:8080/#/` instead.

This PR should fix it. Regarding tests, I'm not sure whether we should change the existing hash-mode test specs or create a new one.