### PR TITLE
Silence default child warning when redirecting

### DIFF
--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -77,11 +77,11 @@ function addRouteRecord (
   }
 
   if (route.children) {
-    // Warn if route is named and has a default child route.
+    // Warn if route is named, does not redirect and has a default child route.
     // If users navigate to this route by name, the default child will
     // not be rendered (GH Issue #629)
     if (process.env.NODE_ENV !== 'production') {
-      if (route.name && route.children.some(child => /^\/?$/.test(child.path))) {
+      if (route.name && !route.redirect && route.children.some(child => /^\/?$/.test(child.path))) {
         warn(
           false,
           `Named Route '${route.name}' has a default child route. ` +

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -21,6 +21,19 @@ const routes = [
         name: 'bar.baz'
       }
     ]
+  },
+  {
+    path: '/bar-redirect',
+    name: 'bar-redirect',
+    redirect: { name: 'bar-redirect.baz' },
+    component: Bar,
+    children: [
+      {
+        path: '',
+        component: Baz,
+        name: 'bar-redirect.baz'
+      }
+    ]
   }
 ]
 
@@ -42,7 +55,7 @@ describe('Creating Route Map', function () {
   })
 
   it('has a pathList which places wildcards at the end', () => {
-    expect(maps.pathList).toEqual(['', '/foo', '/bar/', '/bar', '*'])
+    expect(maps.pathList).toEqual(['', '/foo', '/bar/', '/bar', '/bar-redirect/', '/bar-redirect', '*'])
   })
 
   it('has a nameMap object for default subroute at \'bar.baz\'', function () {
@@ -52,7 +65,7 @@ describe('Creating Route Map', function () {
   it('in development, has logged a warning concerning named route of parent and default subroute', function () {
     process.env.NODE_ENV = 'development'
     maps = createRouteMap(routes)
-    expect(console.warn).toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledTimes(1)
     expect(console.warn.calls.argsFor(0)[0]).toMatch('vue-router] Named Route \'bar\'')
   })
 


### PR DESCRIPTION
There is no need to warn about a named route that has a default child route if the named route intentionally redirects.