### PR TITLE
Fix popstate handler sending wrong parameters to scrollBehavior

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -17,9 +17,10 @@ export class HTML5History extends History {
     }
 
     window.addEventListener('popstate', e => {
+      const current = this.current
       this.transitionTo(getLocation(this.base), route => {
         if (expectScroll) {
-          handleScroll(router, route, this.current, true)
+          handleScroll(router, route, current, true)
         }
       })
     })


### PR DESCRIPTION
I found that the `scrollBehavior` callback received the same route object as `to` and `from` parameters when users click the browser's back/forward button.

Then I followed the call stacks and found that there was a one line bug at `history/html5.js`

```javascript
    window.addEventListener('popstate', e => {
      this.transitionTo(getLocation(this.base), route => {
        if (expectScroll) {
          handleScroll(router, route, this.current, true)
        }
      })
    })
```
Actually the `this.current` is changed before the callback be called.

Since it's a bit hard to provide a history-mode demo in codepen/jsfiddle, and  the bug is so obvious.
There is any demo be provided. Sorry about that.

version: vue-router 2.5.3