### PR TITLE
german docs: fixed typos and punctuation and grammatical issues

### DIFF
--- a/docs/de/advanced/data-fetching.md
+++ b/docs/de/advanced/data-fetching.md
@@ -1,8 +1,8 @@
 # Daten laden
 
-Oftmals Müssen wir Daten von einem Server laden, sobald eine Route aktiviert wird. Zum Beispiel müssen die Daten des Users vom Server geladen werden, bevor das Userprofil angezeigt werden kann. Dies kann auf zwei Arten erreicht werden:
+Oftmals müssen wir Daten von einem Server laden, sobald eine Route aktiviert wird. Zum Beispiel müssen die Daten des Users vom Server geladen werden, bevor das Userprofil angezeigt werden kann. Dies kann auf zwei Arten erreicht werden:
 
-- **Laden nach der Navigation**: Der Router schließt zuerst die Navigation ab und wir laden die Daten anschließend in der neuen Komponente. Während der Übertragung kann ein Ladebalken oder ähnliches angezeigt in der Komponente werden.
+- **Laden nach der Navigation**: Der Router schließt zuerst die Navigation ab und wir laden die Daten anschließend in der neuen Komponente. Während der Übertragung kann ein Ladebalken oder ähnliches in der Komponente angezeigt werden.
 
 - **Laden der Navigation**: Wir laden Daten bevor die Navigation der Route durchgeführt wird und navigieren danach erst zur neuen Route.
 
@@ -110,4 +110,4 @@ export default {
 }
 ```
 
-Der Nutzer bleibt im aktuellen View, während die Daten für den neuen View geladen werden. Daher ist es empfehlenswert, derwiel anderswo in der App einen Ladebalken oder ähnliches anzuzeigen. Wenn der Ladevorgang fehlschlägt, ist es außerdem wichtig, eine Fehlermeldung auszugeben.
+Der Nutzer bleibt im aktuellen View, während die Daten für den neuen View geladen werden. Daher ist es während des Ladevorgangs empfehlenswert, innerhalb der App einen Ladebalken oder ähnliches anzuzeigen. Wenn der Ladevorgang fehlschlägt, ist es außerdem wichtig, eine Fehlermeldung auszugeben.

--- a/docs/de/advanced/lazy-loading.md
+++ b/docs/de/advanced/lazy-loading.md
@@ -15,7 +15,7 @@ const Foo = resolve => {
 }
 ```
 
-Es gibt auch eine alternative Code-Splitting Syntax mit `require` im AMD-Stil, mit der das ganze Folgendermaßen vereinfacht werden kann:
+Es gibt auch eine alternative Code-Splitting Syntax mit `require` im AMD-Stil, mit der das ganze folgendermaßen vereinfacht werden kann:
 
 ``` js
 const Foo = resolve => require(['./Foo.vue'], resolve)
@@ -33,7 +33,7 @@ const router = new VueRouter({
 
 ### Gruppierung von Komponenten im selben Chunk
 
-Manchmal wollen wir alle Komponenten unter der selben Route in den selben ansynchronen Chunk gruppieren. Dafür benutzern wir das ["named Chunks" (englisch)](https://webpack.js.org/guides/code-splitting-require/#chunkname) Feature, indem wir einen Chunk-Namen als drittes Argument für `require.ensure` hinzugefügen.
+Manchmal wollen wir alle Komponenten unter derselben Route in den selben ansynchronen Chunk gruppieren. Dafür benutzern wir das ["named Chunks" (englisch)](https://webpack.js.org/guides/code-splitting-require/#chunkname) Feature, indem wir einen Chunk-Namen als drittes Argument für `require.ensure` hinzufügen.
 
 ``` js
 const Foo = r => require.ensure([], () => r(require('./Foo.vue')), 'group-foo')
@@ -41,4 +41,4 @@ const Bar = r => require.ensure([], () => r(require('./Bar.vue')), 'group-foo')
 const Baz = r => require.ensure([], () => r(require('./Baz.vue')), 'group-foo')
 ```
 
-Webpack bündelt alle asynchronen Module mit dem gleichen Chunk-Namen in denselben asynchronen Chunk. Das bedeutet auch, dass keine Dependencies mehr für `require.ensure` explizit aufgelistet werden müssen - daher der leere Array als Argument.
+Webpack bündelt alle asynchronen Module mit dem gleichen Chunk-Namen in denselben asynchronen Chunk. Das bedeutet auch, dass keine Dependencies mehr für `require.ensure` explizit aufgelistet werden müssen - daher das leere Array als Argument.

--- a/docs/de/advanced/navigation-guards.md
+++ b/docs/de/advanced/navigation-guards.md
@@ -2,7 +2,7 @@
 
 Wie der Name schon andeutet, werden "navigation guards" `vue-router` primär genutzt, um Navigationen zu "bewachen", indem diese bei Bedarf redirected oder abgebrochen werden. Es gibt dabei verschiedene Möglichkeiten, sich in den Navigationsprozess einzuklinken: global, in der Route Definition oder direkt in der Komponente.
 
-Hinweis: Guards werden nicht ausgelöst, wenn du Params oder Querys änderst. Beobachte in diesen Fällen einfach [das `$route`-Objekt](../essentials/dynamic-matching.md#reacting-to-params-changes), um auf Änderungen zu reagieren.
+Hinweis: Guards werden nicht ausgelöst, wenn Params oder Querys geändert werden. Beobachte in diesen Fällen einfach [das `$route`-Objekt](../essentials/dynamic-matching.md#reacting-to-params-changes), um auf Änderungen zu reagieren.
 
 ### Globale Guards
 
@@ -16,7 +16,7 @@ router.beforeEach((to, from, next) => {
 })
 ```
 
-Globale Before-Guards werden in der Reihenfolge aufgerufen, in der du sie registriert hast, wann immer eine Navigation ausgelöst wird. Der guard lann auch auch asynchron beendet werden, und die Navigation ist solange im Status **pending**, bis alle bearbeitet wurden.
+Globale Before-Guards werden in der Reihenfolge aufgerufen, in der sie registriert wurden, wann immer eine Navigation ausgelöst wird. Der guard lann auch auch asynchron beendet werden - die Navigation ist solange im Status **pending**, bis alle bearbeitet wurden.
 
 Jede Guard Funktion erhält drei Argumente:
 

--- a/docs/de/advanced/scroll-behavior.md
+++ b/docs/de/advanced/scroll-behavior.md
@@ -1,6 +1,6 @@
 # Scroll-Verhalten
 
-Oft wollen wir, dass die Seite nach oben scrollt, wenn zu einer neuen Route navigiert wird, oder dass die Scroll-Position von Verlaufseinträgen wie beim Neuladen einer Seite beibehalten wird. `vue-router` ermöglichst das und noch mehr - wir könne das Scroll-Verhalten komplett individualisieren.
+Oft wollen wir, dass die Seite nach oben scrollt, wenn zu einer neuen Route navigiert wird, oder dass die Scroll-Position von Verlaufseinträgen wie beim Neuladen einer Seite beibehalten wird. `vue-router` ermöglichst das und noch mehr - wir können das Scroll-Verhalten komplett individualisieren.
 
 > Merke: Dies funktioniert nur im HTML5-Verlaufsmodus ("history mode").
 
@@ -22,7 +22,7 @@ Die Funktion sollte ein Objekt zurückgeben, dass die Scroll-Position beschreibt
 - `{ x: number, y: number }`
 - `{ selector: string }`
 
-Wenn ein falsch-artiger (falsy) Wert oder ein leeres Objekt zurückgegeben wird, wird nicht gescrollt.
+Wenn ein falscher (falsy) Wert oder ein leeres Objekt zurückgegeben wird, wird nicht gescrollt.
 
 Im folgenden Beispiel scrollt die Seite komplett nach oben:
 ``` js
@@ -32,7 +32,7 @@ scrollBehavior (to, from, savedPosition) {
 ```
 
 
-Wenn die Function das `savedPosition`-Object zurückgibt, verhält sich die Seite ähnlich wie bei der Browser selbst bei normalen Websites, wenn mit den Vor-/Zurück-Buttons des Browsers navigiert wird.
+Wenn die Funktion das `savedPosition`-Object zurückgibt, verhält sich die Seite wie ein Browser, innerhalb dessen mit den Vor-/Zurück Buttons navigiert wird.
 
 ``` js
 scrollBehavior (to, from, savedPosition) {
@@ -45,6 +45,7 @@ scrollBehavior (to, from, savedPosition) {
 ```
 
 Simulation des "Scrolle zum Anchor"-Verhaltens:
+
 ``` js
 scrollBehavior (to, from, savedPosition) {
   if (to.hash) {

--- a/docs/de/advanced/transitions.md
+++ b/docs/de/advanced/transitions.md
@@ -34,7 +34,7 @@ const Bar = {
 
 ### Route-basierter dynamischer Übergang
 
-Es ist auch möglich den Übergang dynamisch anhand der Beziehung zwischen Ziel- und aktueller Route festzulegen:
+Es ist auch möglich, den Übergang dynamisch anhand der Beziehung zwischen Ziel- und aktueller Route festzulegen:
 
 ``` html
 <!-- nutze einen dynamischen Übergangsnamen -->
@@ -55,4 +55,4 @@ watch: {
 }
 ```
 
-Komplette Beispiel [hier](https://github.com/vuejs/vue-router/blob/dev/examples/transitions/app.js) ansehen.
+Komplettes Beispiel [hier](https://github.com/vuejs/vue-router/blob/dev/examples/transitions/app.js) ansehen.

--- a/docs/de/api/component-injections.md
+++ b/docs/de/api/component-injections.md
@@ -10,7 +10,7 @@ Die folgenden Eigenschaften werden in jede Child-Komponente injiziert, wenn man 
 
 - #### $route
 
-  Die aktuell aktive [Route](route-object.md). Diese Eigenschaft ist schreibgeschützt und ihre Eigenschaften sind unveränderbar, aber sie kann überwacht werden.
+  Die aktuell aktive [Route](route-object.md). Diese Eigenschaft ist schreibgeschützt und ihre Eigenschaften sind unveränderbar - aber sie kann überwacht werden.
 
 ### Aktivierte Optionen
 

--- a/docs/de/api/options.md
+++ b/docs/de/api/options.md
@@ -30,9 +30,9 @@
 
   Bestimmt den Router-Mode.
 
-  - `hash`: Nutzt den URL-Hash für das Routing. Funktioniert in allen Vue-unterstützten Browsern, inklusive derer, die HTML5 Verlaufs-API nicht unterstützen.
+  - `hash`: Nutzt den URL-Hash für das Routing. Funktioniert in allen Vue-unterstützten Browsern, inklusive derer, die die HTML5 Verlaufs-API nicht unterstützen.
 
-  - `history`: Benötigt HTML5 Verlaufs-API und Serverkonfiguration. Siehe [HTML5 Verlaufsmodus](../essentials/history-mode.md).
+  - `history`: Benötigt die HTML5 Verlaufs-API und Serverkonfiguration. Siehe [HTML5 Verlaufsmodus](../essentials/history-mode.md).
 
   - `abstract`: Funktioniert in jeder JavaScript-Umgebung, zB. serverseitig mit Node.js. **Der Router wird automatisch in diesen Modus gezwungen, wenn keine Browser-API vorhanden ist.**
 

--- a/docs/de/api/route-object.md
+++ b/docs/de/api/route-object.md
@@ -12,7 +12,7 @@ Das Route-Objekt kann an mehreren Orten gefunden werden:
 
 - als Rückgabewert von `router.match(location)`
 
-- in Navigation-Guards als die ersten zwei Argumente:
+- in Navigation-Guards als die ersten beiden Argumente:
 
   ``` js
   router.beforeEach((to, from, next) => {
@@ -20,7 +20,7 @@ Das Route-Objekt kann an mehreren Orten gefunden werden:
   })
   ```
 
-- in der `scrollBehavior`-Funktion als die ersten zwei Argumente:
+- in der `scrollBehavior`-Funktion als die ersten beiden Argumente:
 
   ``` js
   const router = new VueRouter({
@@ -48,7 +48,7 @@ Das Route-Objekt kann an mehreren Orten gefunden werden:
 
   - Typ: `Object`
 
-    Ein Objekt, welches Schlüssel/Wert-Paare des Query-Strings enthält. Für den Pfad `/foo?user=1` erhält man zum Beispiel `$route.query.user == 1`. Gibt es keine Query, ist der Wert ein leeres Objekt.
+    Ein Objekt, welches Schlüssel/Wert-Paare des Query-Strings enthält. Für den Pfad `/foo?user=1` erhält man zum Beispiel `$route.query.user == 1`. Gibt es kein Query, ist der Wert ein leeres Objekt.
 
 - **$route.hash**
 
@@ -82,7 +82,7 @@ Das Route-Objekt kann an mehreren Orten gefunden werden:
   })
   ```
 
-  Wenn die URL `/foo/bar` ist, ist `$route.matched` ein Array, welcher beide geklonten Objekte von Parent nach Child sortiert enthält.
+  Wenn die URL `/foo/bar` ist, ist `$route.matched` ein Array, welches beide geklonten Objekte von Parent nach Child sortiert enthält.
 
 - **$route.name**
 

--- a/docs/de/api/router-instance.md
+++ b/docs/de/api/router-instance.md
@@ -19,7 +19,7 @@
 
 - Typ: `Route`
 
-  Die akuelle Route wiedergespiegelt als [Route-Objekt](route-object.md).
+  Die akuelle Route, widergespiegelt als [Route-Objekt](route-object.md).
 
 ### Methoden
 
@@ -39,11 +39,11 @@
 
 - **router.getMatchedComponents(location?)**
 
-  Gibt einen Array von Komponenten (Definition/Konstruktor, nicht Instanz) zurück, die für den gegebenen Ort oder die aktuelle Route gematched wurden. Wird meist bei serverseitigem Rendern genutzt, um ein Vor-Laden von Daten zu ermöglichen.
+  Gibt ein Array von Komponenten (Definition/Konstruktor, nicht Instanz) zurück, die für den gegebenen Ort oder die aktuelle Route gematched wurden. Wird meist bei serverseitigem Rendern genutzt, um ein Vorladen von Daten zu ermöglichen.
 
 - **router.resolve(location, current?, append?)**
 
-  Umgekehrte URL-Erkennung. Wenn man einZiel in gleicher Form wie in `<router-link>` übergibt, gibt die Funktion ein Objekt mit den folgenden Eigenschaften zurück:
+  Umgekehrte URL-Erkennung. Wenn man ein Ziel in gleicher Form wie in `<router-link>` übergibt, gibt die Funktion ein Objekt mit den folgenden Eigenschaften zurück:
 
 ``` js
 {
@@ -57,12 +57,12 @@
 
   > 2.2.0+
 
-  Füge dynamisch weitere Routes zum Router hinzu. Das  Argument must be an Array mit dem gleichen Format wie die `routes` Konstruktor-Option sein.
+  Füge dynamisch weitere Routen zum Router hinzu. Das Argument muss ein Array mit demselben Format wie die `routes` Konstruktor-Option sein.
 
 - **router.onReady(callback)**
 
   > 2.2.0+
 
-  Diese Methode queued eine Callback-Funktion, welche aufgerufen wird sobald der router die initiale Navigation beendet hat - das heißt, dass alle asynchronen Komponenten und enter-hooks, die zu der aktuellen Route gehören geladen und ausgeführt wurden.
+  Diese Methode queued eine Callback-Funktion, welche aufgerufen wird, sobald der Router die initiale Navigation beendet hat - das heißt, dass alle asynchronen Komponenten und enter-hooks, die zu der aktuellen Route gehören, geladen und ausgeführt wurden.
 
-  Damit kann man im serverseitigen Rendern sicherstellen, dass auf dem Server und im Client der gleiche Output gerendert wird.
+  Damit lässt sich im serverseitigen Rendern sicherstellen, dass auf dem Server und im Client der gleiche Output gerendert wird.

--- a/docs/de/api/router-link.md
+++ b/docs/de/api/router-link.md
@@ -73,7 +73,7 @@
 
   - Default: `"a"`
 
-  Manchmal soll `<router-link>` einen anderen Tag rendern, zB. `<li>`. Mit Hilfe des `tag`-Props kann man definieren, welcher tag gerendert werden soll. Der Tag reagiert nach wie vor auf Klick-Events für die Navigation.
+  Manchmal soll `<router-link>` einen anderen Tag rendern, zB. `<li>`. Mit Hilfe des `tag`-Props kann man definieren, welcher Tag gerendert werden soll. Der Tag reagiert nach wie vor auf Klick-Events für die Navigation.
 
   ``` html
   <router-link to="/foo" tag="li">foo</router-link>

--- a/docs/de/api/router-link.md
+++ b/docs/de/api/router-link.md
@@ -1,12 +1,12 @@
 # `<router-link>`
 
-`<router-link>` ist eine Komponente zum Auslösen von Nutzernavigationen. Die Ziel-Route wird mit der `to`-Prop angegeben. Sie wird standardmäßig als `<a>` mit korrektem `href` Attribut gerendert, das Element kann jedoch mit dem `tag`-Prop geändert werden. Darüberhinaus erhält der Link automatisch die "active" CSS-Klasse, wenn die Ziel-Route gerade aktiv ist.
+`<router-link>` ist eine Komponente zum Auslösen von Nutzernavigationen. Die Ziel-Route wird mit der `to`-Prop angegeben. Sie wird standardmäßig als `<a>` mit korrektem `href` Attribut gerendert, das Element kann jedoch mit dem `tag`-Prop geändert werden. Darüber hinaus erhält der Link automatisch die "active" CSS-Klasse, wenn die Ziel-Route gerade aktiv ist.
 
 `<router-link>` ist aus folgenden Gründen gegenüber fest definierten `<a href="">` links zu bevorzugen:
 
-- Funktioniert in allen Router-Modi (history, hash, abstract) gleich. Daher muss man nichts ändern, wenn man Modus jemals wechslen muss oder er automatisch in den Hash-Modus für IE9 zurückfällt.
+- Funktioniert in allen Router-Modi (history, hash, abstract) gleich. Daher muss man nichts ändern, wenn man den Modus jemals wechslen sollte oder er automatisch in den Hash-Modus für IE9 zurückfällt.
 
-- Im HTML5-Verlaufsmodus fängt `router-link` das `click`-Event ab, sodass der Browser nicht versucht das Fenster neu zu laden.
+- Im HTML5-Verlaufsmodus fängt `router-link` das `click`-Event ab, sodass der Browser nicht versucht, das Fenster neu zu laden.
 
 - Wenn die `base`-Option im HTML5-Verlaufsmodus genutzt wird, muss man die Base-URL nicht immer wieder in `to` mit angeben.
 
@@ -18,7 +18,7 @@
 
   - Pflichtfeld
 
-  Kennzeichnet die Ziel-Route des Links. Wenn die Komponente geklickt wird, wird der Wert von `to` intern an `router.push()` übergeben - der Wert kann also wie entweder ein String oder ein Objekt sein kann.
+  Kennzeichnet die Ziel-Route des Links. Wenn die Komponente geklickt wird, wird der Wert von `to` intern an `router.push()` übergeben - der Wert kann also entweder ein String oder ein Objekt sein kann.
 
 
   ``` html
@@ -61,7 +61,7 @@
 
   - Default: `false`
 
-  Das Setzen von `append` hängt immer den relativen Pfad an den aktuellen an. Angenommen man navigiert von `/a` zu einem relativen Pfad `b` - ohne `append` gelangt man zu `/b`, mit `append` jedoch wird daraus `/a/b`.
+  Das Setzen von `append` hängt immer den relativen Pfad an den aktuellen an. Angenommen, man navigiert von `/a` zu einem relativen Pfad `b` - ohne `append` gelangt man zu `/b`, mit `append` jedoch wird daraus `/a/b`.
 
   ``` html
   <router-link :to="{ path: 'relative/path'}" append></router-link>
@@ -73,7 +73,7 @@
 
   - Default: `"a"`
 
-  Manchmal soll `<router-link>` einen anderen Tag rendern, zB. `<li>`. Mit Hilfe des `tag`-Props kann man definieren, welcher tag gerednert werden soll. Der Tag reagiert nach wie vor auf Klick-Events für die Navigation.
+  Manchmal soll `<router-link>` einen anderen Tag rendern, zB. `<li>`. Mit Hilfe des `tag`-Props kann man definieren, welcher tag gerendert werden soll. Der Tag reagiert nach wie vor auf Klick-Events für die Navigation.
 
   ``` html
   <router-link to="/foo" tag="li">foo</router-link>
@@ -120,7 +120,7 @@
 
 ### "active" Klasse auf ein äußeres Element anwenden
 
-Machmal soll die aktive Klasse an ein äußeres Element anstatt an das `<a>` gesetzt werden. In diesem Fall kann man das äußere Element als `<router-link>` rendern und damit den `<a>`-Tag umschließen:
+Machmal soll die aktive Klasse an einem äußeren Element anstelle das `<a>` gesetzt werden. In diesem Fall kann man das äußere Element als `<router-link>` rendern und damit den `<a>`-Tag umschließen:
 
 ``` html
 <router-link tag="li" to="/foo">

--- a/docs/de/essentials/getting-started.md
+++ b/docs/de/essentials/getting-started.md
@@ -65,6 +65,6 @@ const app = new Vue({
 
 // Die App ist nun gestartet.
 ```
-Das ganze gibt es natürlich auch als [Live-Beispiel](http://jsfiddle.net/yyx990803/xgrjzsup/) an.
+Das ganze gibt es natürlich auch als [Live-Beispiel](http://jsfiddle.net/yyx990803/xgrjzsup/).
 
 Hinweis: `<router-link>` erhält automatisch die CSS-class `.router-link-active`, wenn die aktuelle Route im Browser der des router-link entspricht. Mehr Infos dazu in der [API-Referenz](../api/router-link.md).

--- a/docs/de/essentials/history-mode.md
+++ b/docs/de/essentials/history-mode.md
@@ -13,8 +13,7 @@ const router = new VueRouter({
 
 Bei Nutzung des Verlaufsmodus sieht die URL "normal" aus, zB. `http://meine-seite.de/benutzer/id` - Wunderschön!
 
-Es gibt jedoch ein Problem: Da unsere App eine sogenannten "Single Page Application (SPA)"
- die komplett im Browser läuft, erhält der Nutzer einen 404-Fehler, wenn er `http://meine-seite.de/benutzer/id` direkt aufruft - denn unter diesem Pfad wird dein Webserver nichts finden.
+Es gibt jedoch ein Problem: Da unsere App eine so genannte "Single Page Application (SPA)" ist, die komplett im Browser läuft, erhält der Nutzer einen 404-Fehler, wenn er `http://meine-seite.de/benutzer/id` direkt aufruft - denn unter diesem Pfad wird dein Webserver nichts finden.
 
 Aber keine Sorge: Um dieses Problem zu beheben, musst du nur eine einzige "catch-all"-Route in deiner Serverkonfiguration ergänzen. Wenn die URL zu keiner statischen Datei gehört, sollte diese Route immer die `index.html` an den Browser senden, in der deine App läuft ist.
 

--- a/docs/de/essentials/named-routes.md
+++ b/docs/de/essentials/named-routes.md
@@ -1,6 +1,6 @@
 # Benannte Routes
 
-Manchmal ist es einfacher einer Route mit einem Namen anzusprechen, besonders bei Links zu einer Route oder dem Ausführen von Navigationen. Den Namen vergibt man beim Erzeugen der Router-Instanz in den `routes`-Optionen:
+Manchmal ist es einfacher, eine Route mit einem Namen anzusprechen. Besonders bei Links zu einer Route oder dem Ausführen von Navigationen. Den Namen vergibt man beim Erzeugen der Router-Instanz in den `routes`-Optionen:
 
 ``` js
 const router = new VueRouter({
@@ -20,7 +20,7 @@ Um mit `router-link` zu einer benannten Route zu verlinken, gibt man ein Objekt 
 <router-link :to="{ name: 'user', params: { userId: 123 }}">User</router-link>
 ```
 
-Dass exakt gleiche Objekt kann auch programmatisch in `router.push()` genutzt werden.
+Das exakt gleiche Objekt kann auch programmatisch in `router.push()` genutzt werden.
 
 
 ``` js

--- a/docs/de/essentials/named-views.md
+++ b/docs/de/essentials/named-views.md
@@ -1,6 +1,6 @@
 # Benannte Views
 
-Manchmal muss man mehrere Views zur selben Zeit darstellen, anstatt sie zu verschachteln, zum Beispiel bei einem Layout mit Hauptteil und Seitenleiste. Hier sind benannte Views nützlich. Anstelle eines einzigen Outlets für die View-Darstellung gibt es mehrere, die Namen tragen können. Ein `router-view` ohne Namen heißt standardmäßig `default`.
+Manchmal muss man mehrere Views zur selben Zeit darstellen, anstatt sie zu verschachteln. Zum Beispiel bei einem Layout mit Hauptteil und Seitenleiste. Hier sind benannte Views nützlich. Anstelle eines einzigen Outlets für die View-Darstellung gibt es mehrere, die Namen tragen können. Ein `router-view` ohne Namen heißt standardmäßig `default`.
 
 ``` html
 <router-view class="view one"></router-view>
@@ -8,7 +8,7 @@ Manchmal muss man mehrere Views zur selben Zeit darstellen, anstatt sie zu versc
 <router-view class="view three" name="b"></router-view>
 ```
 
-Ein View wird durch eine Komponente gerendert, deswegen benötigen mehrere Views auch mehrere Komponenten für dieselbe Route. Dabei ist es wichtig `components` (Plural) in den Optionen zu verwenden:
+Ein View wird durch eine Komponente gerendert, deswegen benötigen mehrere Views auch mehrere Komponenten für dieselbe Route. Dabei ist es wichtig, `components` (Plural) in den Optionen zu verwenden:
 
 ``` js
 const router = new VueRouter({

--- a/docs/de/essentials/navigation.md
+++ b/docs/de/essentials/navigation.md
@@ -1,6 +1,6 @@
 # Programmatische Navigation
 
-Neben `router-link` für deklarative Links in Templates können wir mit Hilfe der Methoden der Router-Instanz programmatisch navigieren.
+Neben `router-link` für deklarative Links in Templates, können wir mit Hilfe der Methoden der Router-Instanz programmatisch navigieren.
 
 #### `router.push(location, onComplete?, onAbort?)`
 
@@ -41,7 +41,7 @@ Dise methode verhält sich wie `router.push`, allerdings erstellt sie keinen neu
 
 #### `router.go(n)`
 
-Diese Methode akzeptiert einen einfachen Integer als Parameter der angibt, wie viele Schritte im Browser-Verlauf vor- oder rückwärts zu gehen sind - ähnlich wie `window.history.go(n)`.
+Diese Methode akzeptiert einen einfachen Integer als Parameter, der angibt, wie viele Schritte im Browser-Verlauf vor- oder rückwärts zu gehen sind - ähnlich wie `window.history.go(n)`.
 
 Beispiele
 
@@ -64,7 +64,7 @@ router.go(100)
 
 Vielleicht ist dir aufgefallen, dass `router.push`, `router.replace` und `router.go` Gegenstücke von [`window.history.pushState`, `window.history.replaceState` und `window.history.go`](https://developer.mozilla.org/de/docs/Web/API/History) sind und sie die `window.history`-API imitieren.
 
-Das macht es einfach den Verlauf zu manipulieren, wenn man sich mit den [Browser-Verlauf-APIs](https://developer.mozilla.org/de/docs/Web/Guide/DOM/Manipulating_the_browser_history)
+Das macht es einfach, den Verlauf zu manipulieren, wenn man sich mit den [Browser-Verlauf-APIs](https://developer.mozilla.org/de/docs/Web/Guide/DOM/Manipulating_the_browser_history)
 auskennt.
 
 Erwähnenswert ist, dass Navigationsmethoden von `vue-router` (`push`, `replace`, `go`) in allen router modes (`history`, `hash`, `abstract`) genau gleich funktionieren.

--- a/docs/de/essentials/redirect-and-alias.md
+++ b/docs/de/essentials/redirect-and-alias.md
@@ -2,7 +2,7 @@
 
 ### Redirect (Umleitung)
 
-Ein Redirect bedeutet, dass, wenn der Nutzer `/a` besucht, die URL mit `/b` ersetzt wird und auch die Komponente der Route zu `/b` rendert. Das richtet man in der `routes`-Konfiguration folgendermaßen ein:
+Ein Redirect bedeutet, dass, wenn der Nutzer `/a` besucht, die URL mit `/b` ersetzt wird und auch die Komponente der Route zu `/b` rendert. Das kann in der `routes`-Konfiguration folgendermaßen eingestellt werden:
 
 
 ``` js
@@ -54,7 +54,6 @@ const router = new VueRouter({
 })
 ```
 
-Ein Alias gibt die Möglichkeit eine bestimmte UI-Struktur einer
-beliebigen URL zuzuordnen, anstatt von der verschachtelten Struktur der Konfiguration eingeschränkt zu werden.
+Ein Alias biete die Möglichkeit, eine bestimmte UI-Struktur einer beliebigen URL zuzuordnen, anstatt von der verschachtelten Struktur der Konfiguration eingeschränkt zu werden.
 
 Für die erweiterte Anwendung siehe folgendes [Beispiel](https://github.com/vuejs/vue-router/blob/dev/examples/route-alias/app.js).

--- a/docs/de/installation.md
+++ b/docs/de/installation.md
@@ -8,7 +8,7 @@
 [Unpkg.com](https://unpkg.com) bietet NPM-basierte CDN-Links an. Der obige Link führt immer zur aktuellsten Version auf NPM. Eine genaue Version kann via URL genutzt werden: `https://unpkg.com/vue-router@2.0.0`.
 <!--/email_off-->
 
-Füge `vue-router` nach Vue ein und es installiert sich selbst automatisch:
+Füge `vue-router` nach Vue ein und es installiert sich automatisch selbst:
 
 ``` html
 <script src="/path/to/vue.js"></script>


### PR DESCRIPTION
I've fixed some typos as well as punctuation and grammatical issues in the german translation of the documentation.

Kind regards
Magnus