### PR TITLE
Fix bug where `isObjectEqual` throws exception with null values.

### DIFF
--- a/src/util/route.js
+++ b/src/util/route.js
@@ -74,6 +74,12 @@ export function isSameRoute (a: Route, b: ?Route): boolean {
 }
 
 function isObjectEqual (a = {}, b = {}): boolean {
+  if (a === null) {
+    return b === null
+  }
+  if (b === null) {
+    return false
+  }
   const aKeys = Object.keys(a)
   const bKeys = Object.keys(b)
   if (aKeys.length !== bKeys.length) {

--- a/test/unit/specs/route.spec.js
+++ b/test/unit/specs/route.spec.js
@@ -47,6 +47,18 @@ describe('Route utils', () => {
       expect(isSameRoute(a, b)).toBe(true)
       expect(isSameRoute(a, c)).toBe(false)
     })
+
+    it('null values (regression test for #1566)', () => {
+      const a = {
+        path: '/abc',
+        query: { foo: 'bar' }
+      }
+      const b = {
+        path: '/abc',
+        query: { foo: null }
+      }
+      expect(isSameRoute(a, b)).toBe(false);
+    })
   })
 
   describe('isIncludedRoute', () => {


### PR DESCRIPTION
Fixes #1566.

Need some help with this - I've added a test case, but it wasn't failing to begin with! What's the difference between the case with `<router-link>` on the jsfiddle (https://jsfiddle.net/t8gpt9mk/) and the test case with the JS objects?