### PR TITLE
Handle null values when comparing objects

### DIFF
--- a/src/util/route.js
+++ b/src/util/route.js
@@ -74,6 +74,8 @@ export function isSameRoute (a: Route, b: ?Route): boolean {
 }
 
 function isObjectEqual (a = {}, b = {}): boolean {
+  // handle null value #1566
+  if (!a || !b) return a === b
   const aKeys = Object.keys(a)
   const bKeys = Object.keys(b)
   if (aKeys.length !== bKeys.length) {

--- a/test/unit/specs/route.spec.js
+++ b/test/unit/specs/route.spec.js
@@ -47,6 +47,25 @@ describe('Route utils', () => {
       expect(isSameRoute(a, b)).toBe(true)
       expect(isSameRoute(a, c)).toBe(false)
     })
+
+    it('queries with null values', () => {
+      const a = {
+        path: '/abc',
+        query: { foo: null }
+      }
+      const b = {
+        path: '/abc',
+        query: { foo: null }
+      }
+      const c = {
+        path: '/abc',
+        query: { foo: 5 }
+      }
+      expect(() => isSameRoute(a, b)).not.toThrow()
+      expect(() => isSameRoute(a, c)).not.toThrow()
+      expect(isSameRoute(a, b)).toBe(true)
+      expect(isSameRoute(a, c)).toBe(false)
+    })
   })
 
   describe('isIncludedRoute', () => {


### PR DESCRIPTION
Fix #1566

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

@callumacrae I couldn't see why the error was happening in circleci (infinite loading) and wanted to change some things, so I created a new PR. I hope this doesn't bother you.
To answer your question, the problem was there was a non-caught exception, so I tested that and equality as well. But I should test that as well, let me add a commit for that
