### PR TITLE
[Feature]: Async Route Children

### DIFF
--- a/examples/async-children/app.js
+++ b/examples/async-children/app.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 
-Vue.use(VueRouter);
+Vue.use(VueRouter)
 
 const Home = { template: '<div>home</div>' }
 const Foo = { template: '<div>foo</div>' }
@@ -32,7 +32,7 @@ const router = new VueRouter({
   mode: 'history',
   base: __dirname,
   routes
-});
+})
 
 new Vue({
   router,

--- a/examples/async-children/app.js
+++ b/examples/async-children/app.js
@@ -1,0 +1,55 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+Vue.use(VueRouter);
+
+const Home = { template: '<div>home</div>' }
+const Foo = { template: '<div>foo</div>' }
+const Bar = { template: '<div>bar</div>' }
+
+const routes = [
+  { path: '/', component: Home },
+  { path: '/foo', component: Foo },
+  { path: '/bar', component: Bar },
+  {
+    path: '/basic',
+    component: { template: '<div><router-view class="async-view"></router-view></div>' },
+    loadChildren: () => import('./basic-async').then(asyncConfig => asyncConfig.routes)
+  },
+  {
+    path: '/deep',
+    component: { template: '<div><router-view class="async-view"></router-view></div>' },
+    loadChildren: () => import('./deep-async-a').then(asyncConfig => asyncConfig.routes)
+  },
+  {
+    path: '/default-deep',
+    component: { template: '<div><router-view class="async-view"></router-view></div>' },
+    loadChildren: () => import('./deep-async-default-a').then(asyncConfig => asyncConfig.routes)
+  }
+]
+
+const router = new VueRouter({
+  mode: 'history',
+  base: __dirname,
+  routes
+});
+
+new Vue({
+  router,
+  template: `
+    <div id="app">
+      <h1>Basic</h1>
+      <ul>
+        <li><router-link to="/">/</router-link></li>
+        <li><router-link to="/foo">/foo</router-link></li>
+        <li><router-link to="/bar">/bar</router-link></li>
+        <li><router-link to="/basic">/basic</router-link></li>
+        <li><router-link to="/basic/foo">/basic/foo</router-link></li>
+        <li><router-link to="/basic/bar">/basic/bar</router-link></li>
+        <li><router-link to="/deep/a/b">/deep/a/b</router-link></li>
+        <li><router-link to="/default-deep">/default-deep</router-link></li>
+      </ul>
+      <router-view class="view"></router-view>
+    </div>
+  `
+}).$mount('#app')

--- a/examples/async-children/basic-async.js
+++ b/examples/async-children/basic-async.js
@@ -1,6 +1,3 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
 const BasicDefault = { template: '<div>basic-default</div>' }
 const BasicFoo = { template: '<div>basic-foo</div>' }
 const BasicBar = { template: '<div>basic-bar</div>' }

--- a/examples/async-children/basic-async.js
+++ b/examples/async-children/basic-async.js
@@ -1,0 +1,12 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+const BasicDefault = { template: '<div>basic-default</div>' }
+const BasicFoo = { template: '<div>basic-foo</div>' }
+const BasicBar = { template: '<div>basic-bar</div>' }
+
+export const routes = [
+  { path: '', component: BasicDefault },
+  { path: 'foo', component: BasicFoo },
+  { path: 'bar', component: BasicBar }
+]

--- a/examples/async-children/deep-async-a.js
+++ b/examples/async-children/deep-async-a.js
@@ -1,6 +1,3 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
 const DeepA = { template: '<div><router-view class="async-viewA"></router-view></div>' }
 
 export const routes = [

--- a/examples/async-children/deep-async-a.js
+++ b/examples/async-children/deep-async-a.js
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+const DeepA = { template: '<div><router-view class="async-viewA"></router-view></div>' }
+
+export const routes = [
+  {
+    path: '',
+    component: {},
+    loadChildren: () => Promise.reject('Default async route loaded when it should not have been.')
+  },
+  {
+    path: 'test',
+    component: {},
+    loadChildren: () => Promise.reject('Test async route loaded when it should not have been.')
+  },
+  {
+    path: 'a',
+    component: DeepA,
+    loadChildren: () => import('./deep-async-b').then(asyncConfig => asyncConfig.routes)
+  }
+]

--- a/examples/async-children/deep-async-b.js
+++ b/examples/async-children/deep-async-b.js
@@ -1,6 +1,3 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
 const DeepB = { template: '<div>deep-async-b</div>' }
 
 export const routes = [

--- a/examples/async-children/deep-async-b.js
+++ b/examples/async-children/deep-async-b.js
@@ -1,0 +1,21 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+const DeepB = { template: '<div>deep-async-b</div>' }
+
+export const routes = [
+  {
+    path: '',
+    component: {},
+    loadChildren: () => Promise.reject('Default async route loaded when it should not have been.')
+  },
+  {
+    path: 'test',
+    component: {},
+    loadChildren: () => Promise.reject('Test async route loaded when it should not have been.')
+  },
+  {
+    path: 'b',
+    component: DeepB
+  }
+]

--- a/examples/async-children/deep-async-default-a.js
+++ b/examples/async-children/deep-async-default-a.js
@@ -1,6 +1,3 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
 const DeepA = { template: '<div><router-view class="async-viewA"></router-view></div>' }
 
 export const routes = [

--- a/examples/async-children/deep-async-default-a.js
+++ b/examples/async-children/deep-async-default-a.js
@@ -1,0 +1,17 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+const DeepA = { template: '<div><router-view class="async-viewA"></router-view></div>' }
+
+export const routes = [
+  {
+    path: '',
+    component: DeepA,
+    loadChildren: () => import('./deep-async-default-b').then(asyncConfig => asyncConfig.routes)
+  },
+  {
+    path: 'test',
+    component: {},
+    loadChildren: () => Promise.reject('Test async route loaded when it should not have been.')
+  }
+]

--- a/examples/async-children/deep-async-default-b.js
+++ b/examples/async-children/deep-async-default-b.js
@@ -1,0 +1,16 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+const DeepB = { template: '<div>deep-async-default-b</div>' }
+
+export const routes = [
+  {
+    path: '',
+    component: DeepB
+  },
+  {
+    path: 'test',
+    component: {},
+    loadChildren: () => Promise.reject('Test async route loaded when it should not have been.')
+  }
+]

--- a/examples/async-children/deep-async-default-b.js
+++ b/examples/async-children/deep-async-default-b.js
@@ -1,6 +1,3 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
 const DeepB = { template: '<div>deep-async-default-b</div>' }
 
 export const routes = [

--- a/examples/async-children/index.html
+++ b/examples/async-children/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/global.css">
+<a href="/">&larr; Examples index</a>
+<div id="app"></div>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/async-children.js"></script>

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -27,6 +27,8 @@ declare type NavigationGuard = (
 
 declare type AfterNavigationHook = (to: Route, from: Route) => any
 
+declare type LoadChildrenPromise = () => Promise<RouteConfig[]>;
+
 type Position = { x: number, y: number };
 
 declare type RouterOptions = {
@@ -59,6 +61,7 @@ declare type RouteConfig = {
   props?: boolean | Object | Function;
   caseSensitive?: boolean;
   pathToRegexpOptions?: PathToRegexpOptions;
+  loadChildren: string | LoadChildrenPromise;
 }
 
 declare type RouteRecord = {
@@ -73,6 +76,8 @@ declare type RouteRecord = {
   beforeEnter: ?NavigationGuard;
   meta: any;
   props: boolean | Object | Function | Dictionary<boolean | Object | Function>;
+  loadChildren?: string | LoadChildrenPromise;
+  routeConfig?: RouteConfig;
 }
 
 declare type Location = {

--- a/flow/declarations.js
+++ b/flow/declarations.js
@@ -61,7 +61,7 @@ declare type RouteConfig = {
   props?: boolean | Object | Function;
   caseSensitive?: boolean;
   pathToRegexpOptions?: PathToRegexpOptions;
-  loadChildren: string | LoadChildrenPromise;
+  loadChildren?: string | LoadChildrenPromise | null;
 }
 
 declare type RouteRecord = {
@@ -76,8 +76,8 @@ declare type RouteRecord = {
   beforeEnter: ?NavigationGuard;
   meta: any;
   props: boolean | Object | Function | Dictionary<boolean | Object | Function>;
-  loadChildren?: string | LoadChildrenPromise;
-  routeConfig?: RouteConfig;
+  loadChildren?: string | LoadChildrenPromise | null;
+  routeConfig: RouteConfig;
 }
 
 declare type Location = {

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -19,8 +19,12 @@ export function createMatcher (
 ): Matcher {
   const { pathList, pathMap, nameMap } = createRouteMap(routes)
 
-  function addRoutes (routes) {
-    createRouteMap(routes, pathList, pathMap, nameMap)
+  function addRoutes (routes, parent) {
+    let parentRoute: RouteRecord;
+    if (pathMap && parent) {
+      parentRoute = pathMap[parent];
+    }
+    createRouteMap(routes, pathList, pathMap, nameMap, parentRoute)
   }
 
   function match (

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -73,7 +73,7 @@ export function createMatcher (
     return _createRoute(null, location)
   }
 
-  function loadAsyncChildren(
+  function loadAsyncChildren (
     raw: RawLocation,
     currentRoute: Route
   ): Promise<any> {
@@ -93,7 +93,7 @@ export function createMatcher (
       .then(allChildren => {
         return Promise.all([
           ...allChildren.map((children, i) => {
-            const {path} = asyncMatches[i]
+            const { path } = asyncMatches[i]
             const parent = findParent(pathMap[path])
             return addChildren(parent.routeConfig, children, path, location.path || '/')
               .then(updatedConfig => addRoutes([updatedConfig]))

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -8,7 +8,8 @@ export function createRouteMap (
   routes: Array<RouteConfig>,
   oldPathList?: Array<string>,
   oldPathMap?: Dictionary<RouteRecord>,
-  oldNameMap?: Dictionary<RouteRecord>
+  oldNameMap?: Dictionary<RouteRecord>,
+  parentRoute?: RouteRecord
 ): {
   pathList: Array<string>;
   pathMap: Dictionary<RouteRecord>;
@@ -20,7 +21,7 @@ export function createRouteMap (
   const nameMap: Dictionary<RouteRecord> = oldNameMap || Object.create(null)
 
   routes.forEach(route => {
-    addRouteRecord(pathList, pathMap, nameMap, route)
+    addRouteRecord(pathList, pathMap, nameMap, route, parentRoute)
   })
 
   // ensure wildcard routes are always at the end

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -49,7 +49,7 @@ function addRouteRecord (
   matchAs?: string
 ) {
   const { path, name } = route
-  const hasAsyncChildren = typeof route.loadChildren === 'function';
+  const hasAsyncChildren = typeof route.loadChildren === 'function'
 
   if (process.env.NODE_ENV !== 'production') {
     assert(path != null, `"path" is required in a route configuration.`)
@@ -95,11 +95,12 @@ function addRouteRecord (
       ? {}
       : route.components
         ? route.props
-        : { default: route.props }
+        : { default: route.props },
+    routeConfig: route
   }
 
   if (hasAsyncChildren) {
-    record.loadChildren = route.loadChildren;
+    record.loadChildren = route.loadChildren
   }
 
   if (route.children) {
@@ -134,6 +135,7 @@ function addRouteRecord (
     aliases.forEach(alias => {
       const aliasRoute = {
         path: alias,
+        loadChildren: route.loadChildren,
         children: route.children
       }
       addRouteRecord(

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -167,7 +167,6 @@ function addRouteRecord (
       pathList.push(pathList.splice(parentIndex, 1)[0])
     }
   }
-  
 
   if (name) {
     if (!nameMap[name] || nameMap[name].path === record.path) {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -81,7 +81,7 @@ function addRouteRecord (
 
   const record: RouteRecord = {
     path: normalizedPath,
-    regex: compileRouteRegex(normalizedPath, pathToRegexpOptions),
+    regex: compileRouteRegex(normalizedPath, pathToRegexpOptions, hasAsyncChildren),
     components: route.components || { default: route.component },
     instances: {},
     name,
@@ -164,8 +164,8 @@ function addRouteRecord (
   }
 }
 
-function compileRouteRegex (path: string, pathToRegexpOptions: PathToRegexpOptions): RouteRegExp {
-  const regex = Regexp(path, [], pathToRegexpOptions)
+function compileRouteRegex (path: string, pathToRegexpOptions: PathToRegexpOptions, async?: boolean): RouteRegExp {
+  const regex = Regexp(`${path}${async ? '(\/{0,1}.*)' : ''}`, [], pathToRegexpOptions)
   if (process.env.NODE_ENV !== 'production') {
     const keys: any = {}
     regex.keys.forEach(key => {
@@ -177,8 +177,7 @@ function compileRouteRegex (path: string, pathToRegexpOptions: PathToRegexpOptio
 }
 
 function normalizePath (path: string, parent?: RouteRecord, strict?: boolean, async?: boolean): string {
-  if (!strict) path = path.replace(/\/$/, '')
-  if (async) path = `${path}(\/{0,1}.*)`;
+  if (!strict || async) path = path.replace(/\/$/, '')
   if (path[0] === '/') return path
   if (parent == null) return path
   return cleanPath(`${parent.path}/${path}`)

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -61,16 +61,14 @@ export class History {
     this.errorCbs.push(errorCb)
   }
 
-  transitionTo (location: RawLocation, onComplete?: Function, onAbort?: Function, childrenLoaded?: boolean) {
+  transitionTo (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const route = this.router.match(location, this.current)
     this.confirmTransition(route, () => {
-      this.updateRoute(route)
-
-      if (route.loadChildren && !childrenLoaded) {
-        this.router.matcher.loadAsyncChildren(route)
+      if (route.loadChildren) {
+        this.router.matcher.loadAsyncChildren(location, route)
           .then(() => {
             // Perform transition again to ensure the proper component hierarchy is loaded
-            this.transitionTo(location, onComplete, onAbort, true)
+            this.transitionTo(location, onComplete, onAbort)
           })
           .catch((err) => {
             if (onAbort) {
@@ -83,6 +81,7 @@ export class History {
             }
           })
       } else {
+        this.updateRoute(route)
         onComplete && onComplete(route)
         this.ensureURL()
 

--- a/src/index.js
+++ b/src/index.js
@@ -206,8 +206,8 @@ export default class VueRouter {
     }
   }
 
-  addRoutes (routes: Array<RouteConfig>) {
-    this.matcher.addRoutes(routes)
+  addRoutes (routes: Array<RouteConfig>, parent?: string) {
+    this.matcher.addRoutes(routes, parent)
     if (this.history.current !== START) {
       this.history.transitionTo(this.history.getCurrentLocation())
     }

--- a/src/index.js
+++ b/src/index.js
@@ -206,8 +206,8 @@ export default class VueRouter {
     }
   }
 
-  addRoutes (routes: Array<RouteConfig>, parent?: string) {
-    this.matcher.addRoutes(routes, parent)
+  addRoutes (routes: Array<RouteConfig>) {
+    this.matcher.addRoutes(routes)
     if (this.history.current !== START) {
       this.history.transitionTo(this.history.getCurrentLocation())
     }

--- a/src/util/async-children.js
+++ b/src/util/async-children.js
@@ -1,0 +1,84 @@
+/* @flow */
+
+export function findParent(
+  routeRecord: RouteRecord
+): RouteRecord {
+  if (routeRecord.parent) {
+    return findParent(routeRecord.parent)
+  } else {
+    return routeRecord
+  }
+}
+
+export function loadDefaultAsyncChildren(
+  childrenConfigs: Array<RouteConfig>
+): Promise<RouteConfig[]> {
+  return Promise.all([
+    ...childrenConfigs.map(child => {
+      if (child.path === '' && typeof child.loadChildren === 'function') {
+        return child.loadChildren()
+          .then(asyncChildren =>
+            loadDefaultAsyncChildren(asyncChildren)
+          )
+          .then(asyncChildren => {
+            child.loadChildren = null
+
+            if (child.children) {
+              child.children.push(...asyncChildren)
+            } else {
+              child.children = asyncChildren
+            }
+
+            return child
+          })
+      } else {
+        return child
+      }
+    })
+  ])
+}
+
+export function addChildren(
+  routeConfig: RouteConfig,
+  children: RouteConfig[],
+  childRoutePath: string,
+  location: string
+): Promise<RouteConfig> {
+  let updatedPath = childRoutePath.replace(/^\//, '')
+  let configPath = routeConfig.path.replace(/^\//, '')
+  let updatedLocation = location.replace(/^\//, '').replace(configPath, '')
+
+  if (updatedPath === configPath) {
+    routeConfig.loadChildren = null
+    if (routeConfig.children) {
+      routeConfig.children.push(...children)
+    } else {
+      routeConfig.children = children
+    }
+
+    if (updatedLocation === '') {
+      // User attempting to load default path
+      return loadDefaultAsyncChildren(routeConfig.children || [])
+        .then(asyncChildren => {
+          routeConfig.children = asyncChildren
+          return routeConfig
+        })
+    } else {
+      return Promise.resolve(routeConfig)
+    }
+  } else if (updatedPath.indexOf(configPath) === 0) {
+    updatedPath = updatedPath.replace(configPath, '')
+
+    return Promise.all([
+      ...(routeConfig.children || []).map(child =>
+        addChildren(child, children, updatedPath, location)
+      )
+    ])
+      .then(children => {
+        routeConfig.children = children
+        return routeConfig
+      })
+  } else {
+    return Promise.resolve(routeConfig)
+  }
+}

--- a/src/util/async-children.js
+++ b/src/util/async-children.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export function findParent(
+export function findParent (
   routeRecord: RouteRecord
 ): RouteRecord {
   if (routeRecord.parent) {
@@ -10,7 +10,7 @@ export function findParent(
   }
 }
 
-export function loadDefaultAsyncChildren(
+export function loadDefaultAsyncChildren (
   childrenConfigs: Array<RouteConfig>
 ): Promise<RouteConfig[]> {
   return Promise.all([
@@ -38,15 +38,15 @@ export function loadDefaultAsyncChildren(
   ])
 }
 
-export function addChildren(
+export function addChildren (
   routeConfig: RouteConfig,
   children: RouteConfig[],
   childRoutePath: string,
   location: string
 ): Promise<RouteConfig> {
   let updatedPath = childRoutePath.replace(/^\//, '')
-  let configPath = routeConfig.path.replace(/^\//, '')
-  let updatedLocation = location.replace(/^\//, '').replace(configPath, '')
+  const configPath = routeConfig.path.replace(/^\//, '')
+  const updatedLocation = location.replace(/^\//, '').replace(configPath, '')
 
   if (updatedPath === configPath) {
     routeConfig.loadChildren = null

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -20,6 +20,7 @@ export function createRoute (
     query: location.query || {},
     params: location.params || {},
     fullPath: getFullPath(location, stringifyQuery),
+    loadChildren: record && record.loadChildren ? record.loadChildren : null,
     matched: record ? formatMatch(record) : []
   }
   if (redirectedFrom) {

--- a/test/e2e/specs/async-children.js
+++ b/test/e2e/specs/async-children.js
@@ -63,7 +63,7 @@ module.exports = {
       .waitForElementVisible('#app', 1000)
       .click('li:nth-child(8) a')
       .waitForElementVisible('.async-viewA', 1000)
-      .assert.containsText('.async-viewA', 'deep-async-b')
+      .assert.containsText('.async-viewA', 'deep-async-default-b')
       
     .end()
   }

--- a/test/e2e/specs/async-children.js
+++ b/test/e2e/specs/async-children.js
@@ -1,0 +1,70 @@
+module.exports = {
+  'async children': function (browser) {
+    browser
+    .url('http://localhost:8080/async-children/')
+      .waitForElementVisible('#app', 1000)
+      .assert.count('li a', 8)
+      .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(2) a')
+      .assert.containsText('.view', 'foo')
+
+      .click('li:nth-child(3) a')
+      .assert.containsText('.view', 'bar')
+
+      .click('li:nth-child(1) a')
+      .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(4) a')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-default')
+
+    // test linking to children
+    .url('http://localhost:8080/async-children')
+      .waitForElementVisible('#app', 1000)
+      .click('li:nth-child(4) a')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-default')
+    
+    .url('http://localhost:8080/async-children')
+      .waitForElementVisible('#app', 1000)
+      .click('li:nth-child(5) a')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-foo')
+
+    .url('http://localhost:8080/async-children')
+      .waitForElementVisible('#app', 1000)
+      .click('li:nth-child(6) a')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-bar')
+
+    // test deep linking to children
+    .url('http://localhost:8080/async-children/basic')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-default')
+    
+    .url('http://localhost:8080/async-children/basic/foo')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-foo')
+
+    .url('http://localhost:8080/async-children/basic/bar')
+      .waitForElementVisible('.async-view', 1000)
+      .assert.containsText('.async-view', 'basic-bar')
+    
+    // test deep async loading
+    .url('http://localhost:8080/async-children')
+      .waitForElementVisible('#app', 1000)
+      .click('li:nth-child(7) a')
+      .waitForElementVisible('.async-viewA', 1000)
+      .assert.containsText('.async-viewA', 'deep-async-b')
+
+    // test deep default async loading
+    .url('http://localhost:8080/async-children')
+      .waitForElementVisible('#app', 1000)
+      .click('li:nth-child(8) a')
+      .waitForElementVisible('.async-viewA', 1000)
+      .assert.containsText('.async-viewA', 'deep-async-b')
+      
+    .end()
+  }
+}

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -75,6 +75,39 @@ describe('router.addRoutes', () => {
     expect(components.length).toBe(1)
     expect(components[0].name).toBe('A')
   })
+
+  it('should load children to an existing parent route', function () {
+    const router = new Router({
+      mode: 'abstract',
+      routes: [
+        { path: '/a', component: { name: 'A' }}
+      ]
+    })
+
+    router.push('/a')
+    let components = router.getMatchedComponents()
+    expect(components.length).toBe(1)
+    expect(components[0].name).toBe('A')
+
+    router.push('/a/b')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(0)
+
+    /**
+     * A given route represents a hierarchy of components loaded to the DOM
+     * where each parent must contain a `router-view` for it's children.
+     */
+    router.addRoutes([{ path: 'b', component: { name: 'B' }}], '/a')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(2)
+    expect(components[1].name).toBe('B')
+
+    // make sure it preserves previous routes
+    router.push('/a')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(1)
+    expect(components[0].name).toBe('A')
+  })
 })
 
 describe('router.push/replace callbacks', () => {
@@ -98,7 +131,20 @@ describe('router.push/replace callbacks', () => {
 
     router = new Router({
       routes: [
-        { path: '/foo', component: Foo }
+        { path: '/foo', component: Foo },
+        {
+          path: '/asyncFoo',
+          name: 'asyncFoo',
+          loadChildren: function () {
+            return Promise.resolve([
+              {
+                path: 'asyncBar',
+                name: 'asyncBar',
+                component: Foo
+              }
+            ])
+          }
+        }
       ]
     })
 

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -200,14 +200,14 @@ describe('Creating Route Map', function () {
         {
           name: 'asyncFoo',
           path: '/asyncFoo',
-          loadChildren: () => new Promise(function (resolve) {
-            return [
+          loadChildren: function () {
+            return Promise.resolve([
               {
                 name: 'asyncBar',
                 component: Foo
               }
-            ]
-          })
+            ])
+          }
         }
       ])
 

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -204,6 +204,7 @@ describe('Creating Route Map', function () {
             return Promise.resolve([
               {
                 name: 'asyncBar',
+                path: '/asyncBar',
                 component: Foo
               }
             ])

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -4,6 +4,18 @@ import { createMatcher } from '../../../src/create-matcher'
 const routes = [
   { path: '/', name: 'home', component: { name: 'home' }},
   { path: '/foo', name: 'foo', component: { name: 'foo' }},
+  {
+    path: '/async',
+    name: 'async',
+    loadChildren: function () {
+      return Promise.resolve([
+        {
+          name: 'asyncBar',
+          component: Foo
+        }
+      ])
+    }
+  }
 ]
 
 describe('Creating Matcher', function () {
@@ -31,5 +43,25 @@ describe('Creating Matcher', function () {
   it('in production, it has not logged this warning', function () {
     match({ name: 'foo' }, routes[0])
     expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  describe('async children', function () {
+    it('should match the async route', function () {
+      const { name, matched } = match({ path: '/async' }, routes[0])
+      expect(matched.length).toBe(1)
+      expect(name).toBe('async')
+    })
+
+    it('should match the async route ending with a slash', function () {
+      const { name, matched } = match('/async/' , routes[0])
+      expect(matched.length).toBe(1)
+      expect(name).toBe('async')
+    })
+
+    it('should match the async route when the children have not been loaded', function () {
+      const { name, matched } = match('/async/foo', routes[0])
+      expect(matched.length).toBe(1)
+      expect(name).toBe('async')
+    })
   })
 })

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -63,5 +63,15 @@ describe('Creating Matcher', function () {
       expect(matched.length).toBe(1)
       expect(name).toBe('async')
     })
+
+    it('should container property loadChildren with a value of null for non-async routes', function () {
+      const { loadChildren } = match('/foo', routes[0])
+      expect(loadChildren).toBe(null)
+    })
+
+    it('should container property loadChildren without a value of null for async routes', function () {
+      const { loadChildren } = match('/async/foo', routes[0])
+      expect(loadChildren).not.toBe(null)
+    })
   })
 })

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -12,6 +12,7 @@ export type NavigationGuard = (
   from: Route,
   next: (to?: RawLocation | false | ((vm: Vue) => any) | void) => void
 ) => any
+export type LoadChildrenPromise = () => Promise<RouteConfig[]>;
 
 declare class VueRouter {
   constructor (options?: RouterOptions);
@@ -83,6 +84,7 @@ export interface RouteConfig {
   props?: boolean | Object | RoutePropsFunction;
   caseSensitive?: boolean;
   pathToRegexpOptions?: PathToRegexpOptions;
+  loadChildren?: string | LoadChildrenPromise;
 }
 
 export interface RouteRecord {

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -82,6 +82,24 @@ const router = new VueRouter({
           to.params;
           return "/child";
         }
+      },
+      {
+        path: "asyncChildren-webpackLoader",
+        loadChildren: "./children/routes#routes"
+      },
+      {
+        path: "asyncChildren",
+        loadChildren: () => new Promise(resolve => {
+          resolve([
+            {
+              path: "childA",
+              components: {
+                default: Foo,
+                bar: Bar
+              }
+            }
+          ]);
+        })
       }
     ]},
     { path: "/home", alias: "/" },
@@ -161,7 +179,7 @@ router.go(-1);
 router.back();
 router.forward();
 
-const Components: ComponentOptions<Vue> | typeof Vue = router.getMatchedComponents();
+const Components: (ComponentOptions<Vue> | typeof Vue)[] = router.getMatchedComponents();
 
 const vm = new Vue({
   router,


### PR DESCRIPTION
Async loading of children allows complex child route configurations to be asynchronously loaded into an existing route. This allows developers to more easily split their applications into lazy loaded modules through the likes of Webpack. Only those async children that are routed to are loaded, no unnecessary HTTP calls or processing of children. The only limitation I can see so far with this feature is that nested async named routes are not supported since they are not loaded into the nameMap until the routes are resolved and injected into the router instance.

Example configuration:
```ts
// src/routes.ts
export const routes: VueRouter.RouteConfig[] = [
  {
    path: '/lazy',
    children: async () => new Promise<Vue>(resolve => {
      require.ensure(
        [],
        async require => {
          resolve((require('./lazy/routes') as { routes: VueRouter.RouteConfig[] }).Routes);
        },
        'lazy'
      );
    })
  }
];

// /lazy/routes.ts
export const routes: VueRouter.RouteConfig[] = [
  {
    {
      path: '/one',
      component: OneComponent
    },
    {
      path: '/two',
      component: TwoComponent
    }
  }
];
```