### PR TITLE
Fix scroll when going back to initial route

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -7,6 +7,7 @@ import { getStateKey, setStateKey } from './push-state'
 const positionStore = Object.create(null)
 
 export function setupScroll () {
+  // Fix for #1585 for Firefox
   window.history.replaceState({ key: getStateKey() }, '')
   window.addEventListener('popstate', e => {
     saveScrollPosition()

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -7,6 +7,7 @@ import { getStateKey, setStateKey } from './push-state'
 const positionStore = Object.create(null)
 
 export function setupScroll () {
+  window.history.replaceState({ key: getStateKey() }, '')
   window.addEventListener('popstate', e => {
     saveScrollPosition()
     if (e.state && e.state.key) {

--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -20,6 +20,26 @@ module.exports = {
         return window.pageYOffset === 100
       }, null, 'restore scroll position on back')
 
+      // with manual scroll restoration
+      // https://developers.google.com/web/updates/2015/09/history-api-scroll-restoration
+      .execute(function () {
+        window.scrollTo(0, 100)
+        history.scrollRestoration = 'manual'
+      })
+      .click('li:nth-child(2) a')
+      .assert.containsText('.view', 'foo')
+      .execute(function () {
+        window.scrollTo(0, 200)
+        window.history.back()
+      })
+      .assert.containsText('.view', 'home')
+      .assert.evaluate(function () {
+        return window.pageYOffset === 100
+      }, null, 'restore scroll position on back with manual restoration')
+      .execute(function () {
+        history.scrollRestoration = 'auto'
+      })
+
       // scroll on a popped entry
       .execute(function () {
         window.scrollTo(0, 50)


### PR DESCRIPTION
Should fix: https://github.com/vuejs/vue-router/issues/1585

I added a new e2e test that sets scrollRestoration to manual. Without the fix the test correctly fails.