### PR TITLE
Remove `src` directory from npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "typings": "types/index.d.ts",
   "files": [
-    "src",
     "dist/*.js",
     "types/*.d.ts"
   ],


### PR DESCRIPTION
Continue reducing vue modules size, started in https://github.com/vuejs/vue/pull/6072. Removing `src` directory reduces size of installed `vue-router` package by 30% (240kb instead of 344kb)