### PR TITLE
Add AsyncComponent type to RouteOptions.component

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -1,7 +1,7 @@
 import Vue = require("vue");
-import { ComponentOptions, PluginFunction } from "vue";
+import { ComponentOptions, PluginFunction, AsyncComponent } from "vue";
 
-type Component = ComponentOptions<Vue> | typeof Vue;
+type Component = ComponentOptions<Vue> | typeof Vue | AsyncComponent;
 type Dictionary<T> = { [key: string]: T };
 
 export type RouterMode = "hash" | "history" | "abstract";

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -9,6 +9,7 @@ Vue.use(VueRouter);
 const Home = { template: "<div>home</div>" };
 const Foo = { template: "<div>foo</div>" };
 const Bar = { template: "<div>bar</div>" };
+const AsyncComponent = () => Promise.resolve({ template: "<div>async</div>" })
 
 const Hook: ComponentOptions<Vue> = {
   template: "<div>hook</div>",
@@ -66,7 +67,8 @@ const router = new VueRouter({
         path: "child",
         components: {
           default: Foo,
-          bar: Bar
+          bar: Bar,
+          asyncComponent: AsyncComponent,
         },
         meta: { auth: true },
         beforeEnter (to, from, next) {


### PR DESCRIPTION
AsyncComponent is currently allowed, but typescript is giving me a bogus error. This type definition update fixes this.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
