### PR TITLE
Expose child routes on currentRoute object; add property for a CSS class on inactive routes

### DIFF
--- a/examples/inactive-links/app.js
+++ b/examples/inactive-links/app.js
@@ -1,0 +1,82 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+Vue.use(VueRouter)
+
+const Home = { template: '<div><h2>Home</h2></div>' }
+const About = { template: '<div><h2>About</h2></div>' }
+const Others = { template: '<div><h2>Others</h2></div>' }
+
+const Users = {
+  template: `
+    <div>
+      <h2>Users</h2>
+      <router-view></router-view>
+    </div>
+  `
+}
+
+const User = { template: '<div>{{ $route.params.username }}</div>' }
+
+const router = new VueRouter({
+  mode: 'history',
+  base: __dirname,
+  routes: [
+    { path: '/', component: Home },
+    { path: '/about', component: About },
+    { path: '/others', component: Others },
+    { path: '/users', component: Users,
+      children: [
+        { path: ':username', name: 'user', component: User }
+      ]
+    }
+  ]
+})
+
+new Vue({
+  router,
+  template: `
+    <div id="app">
+      <h1>Active Links</h1>
+      <ul>
+        <li><router-link to="/">/</router-link></li>
+        <li><router-link to="/" exact>/ (exact match)</router-link></li>
+
+        <li><router-link to="/users">/users</router-link></li>
+        <li><router-link to="/users" exact>/users (exact match)</router-link></li>
+
+        <li><router-link to="/users/evan">/users/evan</router-link></li>
+        <li><router-link to="/users/evan#foo">/users/evan#foo</router-link></li>
+        <li>
+          <router-link :to="{ path: '/users/evan', query: { foo: 'bar' }}">
+            /users/evan?foo=bar
+          </router-link>
+        </li>
+        <li><!-- #635 -->
+          <router-link :to="{ name: 'user', params: { username: 'evan' }, query: { foo: 'bar' }}" exact>
+            /users/evan?foo=bar (named view + exact match)
+          </router-link>
+        </li>
+        <li>
+          <router-link :to="{ path: '/users/evan', query: { foo: 'bar', baz: 'qux' }}">
+            /users/evan?foo=bar&baz=qux
+          </router-link>
+        </li>
+
+        <li><router-link to="/about">/about</router-link></li>
+
+        <router-link tag="li" to="/about">
+          <a>/about (active class on outer element)</a>
+        </router-link>
+
+        <li><router-link to="/others" active-class="custom-active" exact-active-class="custom-exact-active" inactive-class="custom-inactive" exact-inactive-class="custom-exact-inactive">/others</router-link></li>
+
+        <router-link tag="li" to="/others" active-class="custom-active" exact-active-class="custom-exact-active" inactive-class="custom-inactive" exact-inactive-class="custom-exact-inactive">
+          <a>/others (active class on outer element)</a>
+        </router-link>
+
+      </ul>
+      <router-view class="view"></router-view>
+    </div>
+  `
+}).$mount('#app')

--- a/examples/inactive-links/index.html
+++ b/examples/inactive-links/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/global.css">
+<style>
+a.router-link-active, li.router-link-active a {
+  color: #f66;
+}
+a.router-link-exact-active, li.router-link-exact-active a {
+  border-bottom: 1px solid #f66;
+}
+a.router-link-inactive, li.router-link-inactive a {
+  color: #f6f;
+}
+a.router-link-exact-inactive, li.router-link-exact-inactive a {
+  border-bottom: 1px solid #f6f;
+}
+
+a.custom-active, li.custom-active a {
+  color: #66f;
+}
+a.custom-exact-active, li.custom-exact-active a {
+  border-bottom: 1px solid #66f;
+}
+a.custom-inactive, li.custom-inactive a {
+  color: #6f6;
+}
+a.custom-exact-inactive, li.custom-exact-inactive a {
+  border-bottom: 1px solid #6f6;
+}
+
+</style>
+<a href="/">&larr; Examples index</a>
+<div id="app"></div>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/inactive-links.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -14,6 +14,7 @@
     <li><a href="named-views">Named Views</a></li>
     <li><a href="route-matching">Route Matching</a></li>
     <li><a href="active-links">Active Links</a></li>
+    <li><a href="inactive-links">Inactive Links</a></li>
     <li><a href="redirect">Redirect</a></li>
     <li><a href="route-props">Route Props</a></li>
     <li><a href="route-alias">Route Alias</a></li>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint src examples",
     "test": "npm run lint && flow check && npm run test:unit && npm run test:e2e && npm run test:types",
     "test:unit": "jasmine JASMINE_CONFIG_PATH=test/unit/jasmine.json",
-    "test:e2e": "node test/e2e/runner.js",
+    "test:e2e": "xvfb-run node test/e2e/runner.js && rm -rf ./xvfb-run.* && rm -rf ./.com.google.* && rm -rf ./.org.chromium.*",
     "test:types": "tsc -p types/test",
     "docs": "cd docs && gitbook install && gitbook serve",
     "docs:deploy": "bash ./build/update-docs.sh",

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -23,8 +23,8 @@ export default {
     replace: Boolean,
     activeClass: String,
     exactActiveClass: String,
-    inactiveClass: String, // TMCDOS
-    exactInactiveClass: String, // TMCDOS
+    inactiveClass: String,
+    exactInactiveClass: String,
     event: {
       type: eventTypes,
       default: 'click'
@@ -38,8 +38,8 @@ export default {
     const classes = {}
     const globalActiveClass = router.options.linkActiveClass
     const globalExactActiveClass = router.options.linkExactActiveClass
-    const globalInactiveClass = router.options.linkInactiveClass; // TMCDOS
-    const globalExactInactiveClass = router.options.linkExactInactiveClass; // TMCDOS
+    const globalInactiveClass = router.options.linkInactiveClass
+    const globalExactInactiveClass = router.options.linkExactInactiveClass
     // Support global empty active class
     const activeClassFallback = globalActiveClass == null
             ? 'router-link-active'
@@ -53,20 +53,18 @@ export default {
     const exactActiveClass = this.exactActiveClass == null
             ? exactActiveClassFallback
             : this.exactActiveClass
-    // === TMCDOS start ===
     const inactiveClassFallback = globalInactiveClass == null
             ? 'router-link-inactive'
-            : globalInactiveClass;
+            : globalInactiveClass
     const exactInactiveClassFallback = globalExactInactiveClass == null
             ? 'router-link-exact-inactive'
-            : globalExactInactiveClass;
+            : globalExactInactiveClass
     const inactiveClass = this.inactiveClass == null
             ? inactiveClassFallback
-            : this.inactiveClass;
+            : this.inactiveClass
     const exactInactiveClass = this.exactInactiveClass == null
             ? exactInactiveClassFallback
-            : this.exactInactiveClass;
-    // === TMCDOS end ===
+            : this.exactInactiveClass
     const compareTarget = location.path
       ? createRoute(null, location, null, router)
       : route
@@ -75,8 +73,8 @@ export default {
     classes[activeClass] = this.exact
       ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
-    classes[exactInactiveClass] = ! classes[exactActiveClass]; // TMCDOS
-    classes[inactiveClass] = ! classes[activeClass]; // TMCDOS
+    classes[exactInactiveClass] = !classes[exactActiveClass]
+    classes[inactiveClass] = !classes[activeClass]
 
     const handler = e => {
       if (guardEvent(e)) {

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -23,6 +23,8 @@ export default {
     replace: Boolean,
     activeClass: String,
     exactActiveClass: String,
+    inactiveClass: String, // TMCDOS
+    exactInactiveClass: String, // TMCDOS
     event: {
       type: eventTypes,
       default: 'click'
@@ -36,6 +38,8 @@ export default {
     const classes = {}
     const globalActiveClass = router.options.linkActiveClass
     const globalExactActiveClass = router.options.linkExactActiveClass
+    const globalInactiveClass = router.options.linkInactiveClass; // TMCDOS
+    const globalExactInactiveClass = router.options.linkExactInactiveClass; // TMCDOS
     // Support global empty active class
     const activeClassFallback = globalActiveClass == null
             ? 'router-link-active'
@@ -49,6 +53,20 @@ export default {
     const exactActiveClass = this.exactActiveClass == null
             ? exactActiveClassFallback
             : this.exactActiveClass
+    // === TMCDOS start ===
+    const inactiveClassFallback = globalInactiveClass == null
+            ? 'router-link-inactive'
+            : globalInactiveClass;
+    const exactInactiveClassFallback = globalExactInactiveClass == null
+            ? 'router-link-exact-inactive'
+            : globalExactInactiveClass;
+    const inactiveClass = this.inactiveClass == null
+            ? inactiveClassFallback
+            : this.inactiveClass;
+    const exactInactiveClass = this.exactInactiveClass == null
+            ? exactInactiveClassFallback
+            : this.exactInactiveClass;
+    // === TMCDOS end ===
     const compareTarget = location.path
       ? createRoute(null, location, null, router)
       : route
@@ -57,6 +75,8 @@ export default {
     classes[activeClass] = this.exact
       ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
+    classes[exactInactiveClass] = ! classes[exactActiveClass]; // TMCDOS
+    classes[inactiveClass] = ! classes[activeClass]; // TMCDOS
 
     const handler = e => {
       if (guardEvent(e)) {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -73,6 +73,8 @@ function addRouteRecord (
     regex: compileRouteRegex(normalizedPath, pathToRegexpOptions),
     components: route.components || { default: route.component },
     instances: {},
+    title: route.title || '', // TMCDOS
+    children: route.children || [], // TMCDOS
     name,
     parent,
     matchAs,

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -73,8 +73,7 @@ function addRouteRecord (
     regex: compileRouteRegex(normalizedPath, pathToRegexpOptions),
     components: route.components || { default: route.component },
     instances: {},
-    title: route.title || '', // TMCDOS
-    children: route.children || [], // TMCDOS
+    children: route.children || [],
     name,
     parent,
     matchAs,

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -15,9 +15,8 @@ export function createRoute (
   const route: Route = {
     name: location.name || (record && record.name),
     meta: (record && record.meta) || {},
-    title: (record && record.title) || '', // TMCDOS
-    children: (record && record.children) || [], // TMCDOS
-    parent: (record && record.parent) || {}, // TMCDOS
+    children: (record && record.children) || [],
+    parent: (record && record.parent) || {},
     path: location.path || '/',
     hash: location.hash || '',
     query: location.query || {},

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -15,6 +15,9 @@ export function createRoute (
   const route: Route = {
     name: location.name || (record && record.name),
     meta: (record && record.meta) || {},
+    title: (record && record.title) || '', // TMCDOS
+    children: (record && record.children) || [], // TMCDOS
+    parent: (record && record.parent) || {}, // TMCDOS
     path: location.path || '/',
     hash: location.hash || '',
     query: location.query || {},

--- a/test/e2e/nightwatch.config.js
+++ b/test/e2e/nightwatch.config.js
@@ -33,7 +33,10 @@ module.exports = {
       'desiredCapabilities': {
         'browserName': 'chrome',
         'javascriptEnabled': true,
-        'acceptSslCerts': true
+        'acceptSslCerts': true,
+        "chromeOptions": {
+          "args" : ["--no-sandbox"]
+        }      
       }
     },
 

--- a/test/e2e/specs/inactive-links.js
+++ b/test/e2e/specs/inactive-links.js
@@ -1,0 +1,64 @@
+
+module.exports = {
+  'inactive links': function (browser) {
+    browser
+    .url('http://localhost:8080/inactive-links/')
+      .waitForElementVisible('#app', 1000)
+      .assert.count('li a', 13)
+      // assert correct href with base
+      .assert.attributeContains('li:nth-child(1) a', 'href', '/inactive-links/')
+      .assert.attributeContains('li:nth-child(2) a', 'href', '/inactive-links/')
+      .assert.attributeContains('li:nth-child(3) a', 'href', '/inactive-links/users')
+      .assert.attributeContains('li:nth-child(4) a', 'href', '/inactive-links/users')
+      .assert.attributeContains('li:nth-child(5) a', 'href', '/inactive-links/users/evan')
+      .assert.attributeContains('li:nth-child(6) a', 'href', '/inactive-links/users/evan#foo')
+      .assert.attributeContains('li:nth-child(7) a', 'href', '/inactive-links/users/evan?foo=bar')
+      .assert.attributeContains('li:nth-child(8) a', 'href', '/inactive-links/users/evan?foo=bar')
+      .assert.attributeContains('li:nth-child(9) a', 'href', '/inactive-links/users/evan?foo=bar&baz=qux')
+      .assert.attributeContains('li:nth-child(10) a', 'href', '/inactive-links/about')
+      .assert.attributeContains('li:nth-child(11) a', 'href', '/inactive-links/about')
+      .assert.attributeContains('li:nth-child(12) a', 'href', '/inactive-links/others')
+      .assert.attributeContains('li:nth-child(13) a', 'href', '/inactive-links/others')
+      .assert.containsText('.view', 'Home')
+
+    assertCustomActiveLinks(12, [12], [13], [12], [13])
+    assertCustomInactiveLinks(10, [12], [13], [12], [13])
+
+    browser.end()
+
+    function assertCustomActiveLinks (n, activeA, activeLI, exactActiveA, exactActiveLI) {
+      browser.click(`li:nth-child(${n}) a`)
+      activeA.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i}) a`, 'custom-active')
+      })
+      activeLI && activeLI.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i})`, 'custom-active')
+      })
+      exactActiveA.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i}) a`, 'custom-exact-active')
+          .assert.cssClassPresent(`li:nth-child(${i}) a`, 'custom-active')
+      })
+      exactActiveLI && exactActiveLI.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i})`, 'custom-exact-active')
+          .assert.cssClassPresent(`li:nth-child(${i})`, 'custom-active')
+      })
+    }
+    function assertCustomInactiveLinks (n, activeA, activeLI, exactActiveA, exactActiveLI) {
+      browser.click(`li:nth-child(${n}) a`)
+      activeA.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i}) a`, 'custom-inactive')
+      })
+      activeLI && activeLI.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i})`, 'custom-inactive')
+      })
+      exactActiveA.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i}) a`, 'custom-exact-inactive')
+          .assert.cssClassPresent(`li:nth-child(${i}) a`, 'custom-inactive')
+      })
+      exactActiveLI && exactActiveLI.forEach(i => {
+        browser.assert.cssClassPresent(`li:nth-child(${i})`, 'custom-exact-inactive')
+          .assert.cssClassPresent(`li:nth-child(${i})`, 'custom-inactive')
+      })
+    }
+  }
+}

--- a/test/unit/specs/children.spec.js
+++ b/test/unit/specs/children.spec.js
@@ -1,0 +1,78 @@
+import Vue from 'vue'
+import VueRouter from '../../../src/index'
+
+Vue.use(VueRouter)
+
+describe('currentRoute', () => {
+  describe('children[]', () => {
+    it('should work', () => {
+      const router = new VueRouter({
+        routes:
+        [
+          {
+            path: '/jobs',
+          },
+          {
+            path: '/setup',
+            children:
+            [
+              {
+                path: 'lists',
+              },
+              {
+                path: 'periods',
+              }
+            ]
+          }
+        ]
+      })
+  
+      router.push('/setup')
+  
+      expect(router.currentRoute.fullPath).toEqual('/setup')
+      expect(router.currentRoute.children.length).toEqual(2)
+      expect(router.currentRoute.children[0].path).toEqual('lists')
+      expect(router.currentRoute.children[1].path).toEqual('periods')
+      expect(router.currentRoute.children[1].fullPath).toEqual(undefined)
+    })
+  })
+
+  describe('parent', () => {
+    it('should work', () => {
+      const router = new VueRouter({
+        routes:
+        [
+          {
+            path: '/jobs',
+          },
+          {
+            path: '/setup',
+            children:
+            [
+              {
+                path: '/',
+                redirect: 'lists'
+              },
+              {
+                path: 'lists',
+              },
+              {
+                path: 'periods',
+              }
+            ]
+          }
+        ]
+      })
+  
+      router.push('/setup/lists')
+  
+      expect(router.currentRoute.fullPath).toEqual('/setup/lists')
+      expect(router.currentRoute.children.length).toEqual(0)
+      expect(router.currentRoute.parent.children.length).toEqual(3)
+      expect(router.currentRoute.parent.children[0].path).toEqual('/')
+      expect(router.currentRoute.parent.children[2].path).toEqual('periods')
+      expect(router.currentRoute.parent.children[2].fullPath).toEqual(undefined)
+      expect(router.currentRoute.parent.fullPath).toEqual(undefined)
+    })
+  })
+})


### PR DESCRIPTION
It is not easy to get access to child routes when you need to render nested menus with `<router-link>`
Publishing **children** on the **$route.currentRoute** solves a real problem. The **parent** property is required so that the route can see its siblings. The **title** property is optional - it is useful instead of **name** when you want to name a route having a default child. I personally use **name** in `beforeRouteEnter/beforeRouteUpdate` to update the **document.title** in browser - and I need it on all routes (even with default child), so I had to add **title** property.

This closes issue #1149

There are non-trivial situations where playing with CSS selectors becomes too inconvenient. Consider the following markup:
```vue
    <div>
      <div class="tabs_account">
        <div class="tab_spacer">&nbsp;</div>
        <template v-for="page in $router.currentRoute.parent.children" v-if="page.can_show">
          <router-link tag="div" active-class="tab_active" inactive-class="tab" v-bind:to="page.path">{{ page.title }}</router-link>
          <div class="tab_spacer">&nbsp;</div>
        </template>
        <div class="tab_fill tab_spacer">&nbsp;</div>
      </div>
      <router-view></router-view>
    </div>
```
You can achieve the same effect like this
```vue
<router-link :class="{'router-link-active': $route.fullPath ==='/' || $route.fullPath === '/a', 'router-link-inactive': $route.fullPath !=='/' && $route.fullPath !== '/a'}" to="/a">
Text
</router-link>
```
but it looks hacky (you have to keep the PATH strings in sync between HTML and JavaScript code) while the proposed solution feels more elegant.
