### PR TITLE
fix #1675

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -193,8 +193,8 @@ export class History {
     })
   }
 
-  shuoldUpdateRoute ():boolean {
-    return true;
+  shuoldUpdateRoute (): boolean {
+    return true
   }
 }
 

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -64,7 +64,7 @@ export class History {
   transitionTo (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const route = this.router.match(location, this.current)
     this.confirmTransition(route, () => {
-      if (this.shuoldUpdateRoute()) {
+      if (this.shouldUpdateRoute()) {
         this.updateRoute(route)
       }
       onComplete && onComplete(route)
@@ -193,7 +193,7 @@ export class History {
     })
   }
 
-  shuoldUpdateRoute (): boolean {
+  shouldUpdateRoute (): boolean {
     return true
   }
 }

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -64,7 +64,9 @@ export class History {
   transitionTo (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const route = this.router.match(location, this.current)
     this.confirmTransition(route, () => {
-      this.updateRoute(route)
+      if (this.shuoldUpdateRoute()) {
+        this.updateRoute(route)
+      }
       onComplete && onComplete(route)
       this.ensureURL()
 
@@ -189,6 +191,10 @@ export class History {
     this.router.afterHooks.forEach(hook => {
       hook && hook(route, prev)
     })
+  }
+
+  shuoldUpdateRoute ():boolean {
+    return true;
   }
 }
 

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -4,7 +4,7 @@ import type Router from '../index'
 import { History } from './base'
 import { cleanPath } from '../util/path'
 import { setupScroll, handleScroll } from '../util/scroll'
-import { pushState, replaceState } from '../util/push-state'
+import { pushState, replaceState, supportsPushState } from '../util/push-state'
 
 export class HTML5History extends History {
   constructor (router: Router, base: ?string) {
@@ -57,6 +57,12 @@ export class HTML5History extends History {
 
   getCurrentLocation (): string {
     return getLocation(this.base)
+  }
+
+  shuoldUpdateRoute (): boolean {
+    // when is ready and don,t support pushState
+    // route shouldn't render, it suppose to be regular page jump
+    return !this.ready || supportsPushState
   }
 }
 

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -59,7 +59,7 @@ export class HTML5History extends History {
     return getLocation(this.base)
   }
 
-  shuoldUpdateRoute (): boolean {
+  shouldUpdateRoute (): boolean {
     // when is ready and don't support pushState
     // route shouldn't render, it suppose to be regular page jump
     return !this.ready || supportsPushState

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -60,7 +60,7 @@ export class HTML5History extends History {
   }
 
   shuoldUpdateRoute (): boolean {
-    // when is ready and don,t support pushState
+    // when is ready and don't support pushState
     // route shouldn't render, it suppose to be regular page jump
     return !this.ready || supportsPushState
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

fix https://github.com/vuejs/vue-router/issues/1675

I add a shouldUpdateRoute method which is always true except in html5.js when the route **isready** and the browser **don't support history pushstate**(such as ie9)

because only history mode have the chance to disable the updateRoute method
which is force ie9 to history mode(fallback: false,  for server render)