### PR TITLE
Improve in-component guard examples

### DIFF
--- a/docs/en/advanced/navigation-guards.md
+++ b/docs/en/advanced/navigation-guards.md
@@ -116,7 +116,27 @@ beforeRouteEnter (to, from, next) {
 }
 ```
 
-You can directly access `this` inside `beforeRouteLeave`. The leave guard is usually used to prevent the user from accidentally leaving the route with unsaved edits. The navigation can be canceled by calling `next(false)`.
+You can directly access `this` inside `beforeRouteEnter` and `beforeRouteLeave`, so using this callback is not necessary and therefore *not supported*:
+
+```js
+beforeRouteUpdate (to, from, next) {
+  this.name = to.params.name
+  next()
+}
+```
+
+The **leave guard** is usually used to prevent the user from accidentally leaving the route with unsaved edits. The navigation can be canceled by calling `next(false)`.
+
+```js
+beforeRouteLeave (to, from , next) {
+  const answer = window.confirm('Do you really want to leave? you have unsaved changes!')
+  if (answer) {
+    next()
+  } else {
+    next(false)
+  }
+}
+```
 
 ### The Full Navigation Resolution Flow
 

--- a/docs/en/advanced/navigation-guards.md
+++ b/docs/en/advanced/navigation-guards.md
@@ -116,10 +116,11 @@ beforeRouteEnter (to, from, next) {
 }
 ```
 
-You can directly access `this` inside `beforeRouteEnter` and `beforeRouteLeave`, so using this callback is not necessary and therefore *not supported*:
+Note that `beforeRouteEnter` is the only hook that supports passing a callback to `next`. For `beforeRouteUpdate` and `beforeRouteLeave`, `this` is already available, so passing a callback is unnecessary and therefore *not supported*:
 
 ```js
 beforeRouteUpdate (to, from, next) {
+  // just use `this`
   this.name = to.params.name
   next()
 }


### PR DESCRIPTION
The section about in-component navigation guards regularly seems to confuse people. We have had several issues and topics on the forum where people tried to passing a callback to `next()` in `beforeRouteUpdate`, event though it has access to this and therefore doesn't support that callback.

Examples: 

* #1582 
* https://forum.vuejs.org/t/ssr-best-hookpoint-to-load-synchronous-component-specific-data/16491/5?u=linusborg
