### PR TITLE
chore: fix invalid type annotation in typings test

### DIFF
--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -163,7 +163,7 @@ router.go(-1);
 router.back();
 router.forward();
 
-const Components: ComponentOptions<Vue> | typeof Vue = router.getMatchedComponents();
+const Components: (ComponentOptions<Vue> | typeof Vue)[] = router.getMatchedComponents();
 
 const vm = new Vue({
   router,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

The current typings test case has invalid type annotation, so the latest TypeScript compiler (v2.4.2) does not pass the test case. I've just fix the annotation to pass the test.

ref #1702 