### PR TITLE
docs(getting-started): Remove horizontal scrolling

### DIFF
--- a/docs/en/essentials/getting-started.md
+++ b/docs/en/essentials/getting-started.md
@@ -30,7 +30,8 @@ Creating a Single-page Application with Vue.js + vue-router is dead simple. With
 ### JavaScript
 
 ``` js
-// 0. If using a module system (e.g. via vue-cli), import Vue and VueRouter and then call `Vue.use(VueRouter)`.
+// 0. If using a module system (e.g. via vue-cli), import Vue and VueRouter
+// and then call `Vue.use(VueRouter)`.
 
 // 1. Define route components.
 // These can be imported from other files


### PR DESCRIPTION
The JavaScript text in the getting-started example was
too wide and caused overflow / horizontal scrolling in the 
'pre' element.

Insert a line break at reasonable place to fix the issue.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
