### PR TITLE
Replace Gitter with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm run docs
 
 ## Questions
 
-For questions and support please use the [Gitter chat room](https://gitter.im/vuejs/vue) or [the official forum](http://forum.vuejs.org). The issue list of this repo is **exclusively** for bug reports and feature requests.
+For questions and support please use the [Discord chat server](https://chat.vuejs.org) or [the official forum](http://forum.vuejs.org). The issue list of this repo is **exclusively** for bug reports and feature requests.
 
 ## Issues
 


### PR DESCRIPTION
Discord is now the official chatroom and it's one of last places where such a change wasn't made.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
