### PR TITLE
Make scrollBehavior work with transitions by handling a promise (fixes #1263)

### DIFF
--- a/examples/scroll-behavior/app.js
+++ b/examples/scroll-behavior/app.js
@@ -20,12 +20,13 @@ const Bar = {
 // - only available in html5 history mode
 // - defaults to no scroll behavior
 // - return false to prevent scroll
-const scrollBehavior = (to, from, savedPosition) => {
+const scrollBehavior = async function (to, from, savedPosition) {
   if (savedPosition) {
     // savedPosition is only available for popstate navigations.
     return savedPosition
   } else {
     const position = {}
+    let delay = 500
     // new navigation.
     // scroll to anchor by returning the selector
     if (to.hash) {
@@ -35,14 +36,20 @@ const scrollBehavior = (to, from, savedPosition) => {
       if (to.hash === '#anchor2') {
         position.offset = { y: 100 }
       }
+
+      if (document.querySelector(to.hash)) {
+        delay = 0
+      }
     }
     // check if any matched route config has meta that requires scrolling to top
     if (to.matched.some(m => m.meta.scrollToTop)) {
-      // cords will be used if no selector is provided,
+      // coords will be used if no selector is provided,
       // or if the selector didn't match any element.
       position.x = 0
       position.y = 0
     }
+    // wait for the out transition to complete (if necessary)
+    await (new Promise(resolve => setTimeout(resolve, delay)))
     // if the returned position is falsy or an empty object,
     // will retain current scroll position.
     return position
@@ -72,7 +79,9 @@ new Vue({
         <li><router-link to="/bar#anchor">/bar#anchor</router-link></li>
         <li><router-link to="/bar#anchor2">/bar#anchor2</router-link></li>
       </ul>
-      <router-view class="view"></router-view>
+      <transition name="fade" mode="out-in">
+        <router-view class="view"></router-view>
+      </transition>
     </div>
   `
 }).$mount('#app')

--- a/examples/scroll-behavior/app.js
+++ b/examples/scroll-behavior/app.js
@@ -20,39 +20,42 @@ const Bar = {
 // - only available in html5 history mode
 // - defaults to no scroll behavior
 // - return false to prevent scroll
-const scrollBehavior = async function (to, from, savedPosition) {
+const scrollBehavior = function (to, from, savedPosition) {
   if (savedPosition) {
     // savedPosition is only available for popstate navigations.
     return savedPosition
   } else {
-    const position = {}
-    let delay = 500
-    // new navigation.
-    // scroll to anchor by returning the selector
-    if (to.hash) {
-      position.selector = to.hash
+    return new Promise(resolve => {
+      const position = {}
+      let delay = 500
+      // new navigation.
+      // scroll to anchor by returning the selector
+      if (to.hash) {
+        position.selector = to.hash
 
-      // specify offset of the element
-      if (to.hash === '#anchor2') {
-        position.offset = { y: 100 }
-      }
+        // specify offset of the element
+        if (to.hash === '#anchor2') {
+          position.offset = { y: 100 }
+        }
 
-      if (document.querySelector(to.hash)) {
-        delay = 0
+        if (document.querySelector(to.hash)) {
+          delay = 0
+        }
       }
-    }
-    // check if any matched route config has meta that requires scrolling to top
-    if (to.matched.some(m => m.meta.scrollToTop)) {
-      // coords will be used if no selector is provided,
-      // or if the selector didn't match any element.
-      position.x = 0
-      position.y = 0
-    }
-    // wait for the out transition to complete (if necessary)
-    await (new Promise(resolve => setTimeout(resolve, delay)))
-    // if the returned position is falsy or an empty object,
-    // will retain current scroll position.
-    return position
+      // check if any matched route config has meta that requires scrolling to top
+      if (to.matched.some(m => m.meta.scrollToTop)) {
+        // coords will be used if no selector is provided,
+        // or if the selector didn't match any element.
+        position.x = 0
+        position.y = 0
+      }
+      // wait for the out transition to complete (if necessary)
+      setTimeout(() => {
+        // if the returned position is falsy or an empty object,
+        // will retain current scroll position.
+        resolve(position)
+      }, delay)
+    })
   }
 }
 

--- a/examples/scroll-behavior/app.js
+++ b/examples/scroll-behavior/app.js
@@ -3,11 +3,11 @@ import VueRouter from 'vue-router'
 
 Vue.use(VueRouter)
 
-const Home = { template: '<div>home</div>' }
-const Foo = { template: '<div>foo</div>' }
+const Home = { template: '<div class="home">home</div>' }
+const Foo = { template: '<div class="foo">foo</div>' }
 const Bar = {
   template: `
-    <div>
+    <div class="bar">
       bar
       <div style="height:500px"></div>
       <p id="anchor" style="height:500px">Anchor</p>

--- a/examples/scroll-behavior/index.html
+++ b/examples/scroll-behavior/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <link rel="stylesheet" href="/global.css">
 <style>
+.fade-enter-active, .fade-leave-active {
+  transition: opacity .5s ease;
+}
+.fade-enter, .fade-leave-active {
+  opacity: 0
+}
 .view {
   border: 1px solid red;
   height: 2000px;

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -36,28 +36,16 @@ export function handleScroll (
 
   // wait until re-render finishes before scrolling
   router.app.$nextTick(() => {
-    let position = getScrollPosition()
+    const position = getScrollPosition()
     const shouldScroll = behavior(to, from, isPop ? position : null)
+
     if (!shouldScroll) {
       return
     }
-    const isObject = typeof shouldScroll === 'object'
-    if (isObject && typeof shouldScroll.selector === 'string') {
-      const el = document.querySelector(shouldScroll.selector)
-      if (el) {
-        let offset = shouldScroll.offset && typeof shouldScroll.offset === 'object' ? shouldScroll.offset : {}
-        offset = normalizeOffset(offset)
-        position = getElementPosition(el, offset)
-      } else if (isValidPosition(shouldScroll)) {
-        position = normalizePosition(shouldScroll)
-      }
-    } else if (isObject && isValidPosition(shouldScroll)) {
-      position = normalizePosition(shouldScroll)
-    }
 
-    if (position) {
-      window.scrollTo(position.x, position.y)
-    }
+    Promise.resolve(shouldScroll).then((shouldScroll) => {
+      scrollToPosition(shouldScroll, position)
+    })
   })
 }
 
@@ -108,4 +96,24 @@ function normalizeOffset (obj: Object): Object {
 
 function isNumber (v: any): boolean {
   return typeof v === 'number'
+}
+
+function scrollToPosition (shouldScroll, position) {
+  const isObject = typeof shouldScroll === 'object'
+  if (isObject && typeof shouldScroll.selector === 'string') {
+    const el = document.querySelector(shouldScroll.selector)
+    if (el) {
+      let offset = shouldScroll.offset && typeof shouldScroll.offset === 'object' ? shouldScroll.offset : {}
+      offset = normalizeOffset(offset)
+      position = getElementPosition(el, offset)
+    } else if (isValidPosition(shouldScroll)) {
+      position = normalizePosition(shouldScroll)
+    }
+  } else if (isObject && isValidPosition(shouldScroll)) {
+    position = normalizePosition(shouldScroll)
+  }
+
+  if (position) {
+    window.scrollTo(position.x, position.y)
+  }
 }

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -42,7 +42,7 @@ export function handleScroll (
     if (!shouldScroll) {
       return
     }
-    
+
     if (typeof shouldScroll.then === 'function') {
       shouldScroll.then(shouldScroll => {
         scrollToPosition(shouldScroll, position)

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -42,10 +42,14 @@ export function handleScroll (
     if (!shouldScroll) {
       return
     }
-
-    Promise.resolve(shouldScroll).then((shouldScroll) => {
+    
+    if (typeof shouldScroll.then === 'function') {
+      shouldScroll.then(shouldScroll => {
+        scrollToPosition(shouldScroll, position)
+      })
+    } else {
       scrollToPosition(shouldScroll, position)
-    })
+    }
   })
 }
 

--- a/test/e2e/nightwatch.config.js
+++ b/test/e2e/nightwatch.config.js
@@ -33,7 +33,12 @@ module.exports = {
       'desiredCapabilities': {
         'browserName': 'chrome',
         'javascriptEnabled': true,
-        'acceptSslCerts': true
+        'acceptSslCerts': true,
+        'chromeOptions': {
+          'args': [
+            'window-size=1280,800'
+          ]
+        }
       }
     },
 

--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -1,6 +1,9 @@
 module.exports = {
   'scroll behavior': function (browser) {
+    const TIMEOUT = 2000
+
     browser
+    .resizeWindow(1280, 800)
     .url('http://localhost:8080/scroll-behavior/')
       .waitForElementVisible('#app', 1000)
       .assert.count('li a', 5)
@@ -10,11 +13,13 @@ module.exports = {
         window.scrollTo(0, 100)
       })
       .click('li:nth-child(2) a')
+      .waitForElementPresent('.view.foo', TIMEOUT)
       .assert.containsText('.view', 'foo')
       .execute(function () {
         window.scrollTo(0, 200)
         window.history.back()
       })
+      .waitForElementPresent('.view.home', TIMEOUT)
       .assert.containsText('.view', 'home')
       .assert.evaluate(function () {
         return window.pageYOffset === 100
@@ -25,6 +30,7 @@ module.exports = {
         window.scrollTo(0, 50)
         window.history.forward()
       })
+      .waitForElementPresent('.view.foo', TIMEOUT)
       .assert.containsText('.view', 'foo')
       .assert.evaluate(function () {
         return window.pageYOffset === 200
@@ -33,12 +39,14 @@ module.exports = {
       .execute(function () {
         window.history.back()
       })
+      .waitForElementPresent('.view.home', TIMEOUT)
       .assert.containsText('.view', 'home')
       .assert.evaluate(function () {
         return window.pageYOffset === 50
       }, null, 'restore scroll position on back again')
 
       .click('li:nth-child(3) a')
+      .waitForElementPresent('.view.bar', TIMEOUT)
       .assert.evaluate(function () {
         return window.pageYOffset === 0
       }, null, 'scroll to top on new entry')
@@ -48,7 +56,9 @@ module.exports = {
         return document.getElementById('anchor').getBoundingClientRect().top < 1
       }, null, 'scroll to anchor')
 
-      .click('li:nth-child(5) a')
+      .execute(function () {
+        document.querySelector('li:nth-child(5) a').click()
+      })
       .assert.evaluate(function () {
         return document.getElementById('anchor2').getBoundingClientRect().top < 101
       }, null, 'scroll to anchor with offset')

--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -3,7 +3,6 @@ module.exports = {
     const TIMEOUT = 2000
 
     browser
-    .resizeWindow(1280, 800)
     .url('http://localhost:8080/scroll-behavior/')
       .waitForElementVisible('#app', 1000)
       .assert.count('li a', 5)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
As stated in the discussion in #1263 this currently works by enabling an arbitrary delay to be used within the `scrollBehavior` handler. A better solution would use an event handler on the router view or at least allow us to get the transition duration. Unfortunately I don't think this is possible - AFAIK we don't have access to the view from within `scrollBehavior`.