### PR TITLE
Add event listeners to router links

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -25,6 +25,7 @@
     <li><a href="auth-flow">Auth Flow</a></li>
     <li><a href="discrete-components">Discrete Components</a></li>
     <li><a href="nested-router">Nested Routers</a></li>
+    <li><a href="link-events">Link Event Handlers</a></li>
   </ul>
 </body>
 </html>

--- a/examples/link-events/app.js
+++ b/examples/link-events/app.js
@@ -1,0 +1,72 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+// 1. Use plugin.
+// This installs <router-view> and <router-link>,
+// and injects $router and $route to all router-enabled child components
+Vue.use(VueRouter)
+
+// 2. Define route components
+const Home = { template: '<div>home</div>' }
+const Foo = { template: '<div>foo</div>' }
+const Bar = { template: '<div>bar</div>' }
+
+// 3. Create the router
+const router = new VueRouter({
+  mode: 'history',
+  base: __dirname,
+  routes: [
+    { path: '/', component: Home },
+    { path: '/foo', component: Foo },
+    { path: '/bar', component: Bar }
+  ]
+})
+
+// 4. Create and mount root instance.
+// Make sure to inject the router.
+// Route components will be rendered inside <router-view>.
+new Vue({
+  router,
+  data () {
+    return {
+      backgroundColor: null,
+      bodyText: null
+    }
+  },
+  methods: {
+    mouseDown () {
+      window.alert('Mouse button pressed')
+    },
+    say (msg) {
+      window.alert(msg)
+    },
+    toggleBgOnClick () {
+      if (this.backgroundColor) {
+        this.backgroundColor = null
+      } else {
+        this.backgroundColor = 'green'
+      }
+    }
+  },
+  computed: {
+    customBackground () {
+      return {
+        backgroundColor: this.backgroundColor
+      }
+    }
+  },
+  template: `
+    <div id="app">
+      <h1>Link Events Handler examples</h1>
+      <ul>
+        <li><router-link to="/" @mouseleave="say('Visit me once in a while!')">/home</router-link></li>
+        <li><router-link to="/foo" @click="say('This got clicked')">/foo</router-link></li>
+        <li><router-link to="/bar" @click="toggleBgOnClick" :style="customBackground">/bar</router-link></li>
+        <router-link tag="li" to="/bar" :event="['mousedown', 'touchstart']" @mousedown="mouseDown">
+          <a>/bar</a>
+        </router-link>
+      </ul>
+      <router-view class="view"></router-view>
+    </div>
+  `
+}).$mount('#app')

--- a/examples/link-events/app.js
+++ b/examples/link-events/app.js
@@ -59,7 +59,7 @@ new Vue({
     <div id="app">
       <h1>Link Events Handler examples</h1>
       <ul>
-        <li><router-link to="/" @mouseleave="say('Visit me once in a while!')">/home</router-link></li>
+        <li><router-link to="/" @mouseup="say('Visit me once in a while!')">/home</router-link></li>
         <li><router-link to="/foo" @click="say('This got clicked')">/foo</router-link></li>
         <li><router-link to="/bar" @click="toggleBgOnClick" :style="customBackground">/bar</router-link></li>
         <router-link tag="li" to="/bar" :event="['mousedown', 'touchstart']" @mousedown="mouseDown">

--- a/examples/link-events/index.html
+++ b/examples/link-events/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/global.css">
+<a href="/">&larr; Examples index</a>
+<div id="app"></div>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/link-events.js"></script>

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -31,6 +31,7 @@ export default {
   render (h: Function) {
     const router = this.$router
     const current = this.$route
+    const listeners = this.$listeners
     const { location, route, href } = router.resolve(this.to, current, this.append)
 
     const classes = {}
@@ -73,6 +74,17 @@ export default {
       this.event.forEach(e => { on[e] = handler })
     } else {
       on[this.event] = handler
+    }
+
+    // allow custom event listeners to co-exist with internal handlers
+    if (listeners) {
+      Object.keys(listeners).forEach(e => {
+        if (on[e]) {
+          on[e] = [on[e], listeners[e]]
+        } else {
+          on[e] = listeners[e]
+        }
+      })
     }
 
     const data: any = {

--- a/test/e2e/specs/link-events.js
+++ b/test/e2e/specs/link-events.js
@@ -1,0 +1,41 @@
+module.exports = {
+  'link-events': function (browser) {
+    browser
+    .url('http://localhost:8080/link-events/')
+      .waitForElementVisible('#app', 1000)
+      .assert.count('li', 4)
+      .assert.count('li a', 4)
+      // assert correct href with base
+      .assert.attributeContains('li:nth-child(1) a', 'href', '/link-events/')
+      .assert.attributeContains('li:nth-child(2) a', 'href', '/link-events/foo')
+      .assert.attributeContains('li:nth-child(3) a', 'href', '/link-events/bar')
+      .assert.attributeContains('li:nth-child(4) a', 'href', '/link-events/bar')
+      .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(2) a')
+      .acceptAlert()
+      .assert.urlEquals('http://localhost:8080/link-events/foo')
+      .assert.containsText('.view', 'foo')
+
+      .click('li:nth-child(3) a')
+      .assert.attributeContains('li:nth-child(3) a', 'style', 'background-color: green;')
+      .assert.urlEquals('http://localhost:8080/link-events/bar')
+      .assert.containsText('.view', 'bar')
+
+      .click('li:nth-child(1) a')
+      .acceptAlert()
+      .assert.urlEquals('http://localhost:8080/link-events/')
+      .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(4) a')
+      .acceptAlert()
+      .assert.urlEquals('http://localhost:8080/link-events/bar')
+      .assert.containsText('.view', 'bar')
+
+    // check initial visit
+    .url('http://localhost:8080/link-events/foo')
+      .waitForElementVisible('#app', 1000)
+      .assert.containsText('.view', 'foo')
+      .end()
+  }
+}

--- a/test/e2e/specs/link-events.js
+++ b/test/e2e/specs/link-events.js
@@ -18,6 +18,7 @@ module.exports = {
       .assert.containsText('.view', 'foo')
 
       .click('li:nth-child(3) a')
+      .waitFor(100)
       .assert.attributeContains('li:nth-child(3) a', 'style', 'background-color: green;')
       .assert.urlEquals('http://localhost:8080/link-events/bar')
       .assert.containsText('.view', 'bar')


### PR DESCRIPTION
This PR should add the possibility to add any kind of event listeners to router-links, since they did not support this.