### PR TITLE
[Doc EN]: `VueRouter` vs. Vue Router // [Doc FR]: Reflect this changes

### DIFF
--- a/docs/en/essentials/getting-started.md
+++ b/docs/en/essentials/getting-started.md
@@ -30,7 +30,7 @@ Creating a Single-page Application with Vue + Vue Router is dead simple. With Vu
 ### JavaScript
 
 ``` js
-// 0. If using a module system (e.g. via vue-cli), import Vue and VueRouter
+// 0. If using a module system (e.g. via vue-cli), import Vue and Vue Router
 // and then call `Vue.use(VueRouter)`.
 
 // 1. Define route components.

--- a/docs/en/essentials/getting-started.md
+++ b/docs/en/essentials/getting-started.md
@@ -30,7 +30,7 @@ Creating a Single-page Application with Vue + Vue Router is dead simple. With Vu
 ### JavaScript
 
 ``` js
-// 0. If using a module system (e.g. via vue-cli), import Vue and Vue Router
+// 0. If using a module system (e.g. via vue-cli), import Vue and VueRouter
 // and then call `Vue.use(VueRouter)`.
 
 // 1. Define route components.

--- a/docs/fr/advanced/lazy-loading.md
+++ b/docs/fr/advanced/lazy-loading.md
@@ -2,7 +2,7 @@
 
 Pendant la construction d'applications avec un empaqueteur (« bundler »), le paquetage JavaScript peut devenir un peu lourd, et donc cela peut affecter le temps de chargement de la page. Il serait plus efficace si l'on pouvait séparer chaque composant de route dans des fragments séparés, et de les charger uniquement lorsque la route est visitée.
 
-En combinant la [fonctionnalité de composant asynchrone](https://fr.vuejs.org/v2/guide/components.html#Composants-asynchrones) de Vue et la [fonctionnalité de séparation de code](https://webpack.js.org/guides/code-splitting-async/) de webpack, il est très facile de charger à la volée les composants de route.
+En combinant la [fonctionnalité de composant asynchrone](https://fr.vuejs.org/v2/guide/components.html#Composants-asynchrones) de Vue et la [fonctionnalité de scission de code](https://webpack.js.org/guides/code-splitting-async/) de webpack, il est très facile de charger à la volée les composants de route.
 
 Premièrement, un composant asynchrone peut définir une fonction fabrique qui retourne une Promesse (qui devrait résoudre le composant lui-même) :
 

--- a/docs/fr/essentials/getting-started.md
+++ b/docs/fr/essentials/getting-started.md
@@ -30,7 +30,7 @@ Créer une application monopage avec Vue + Vue Router est vraiment simple. Avec 
 ### JavaScript
 
 ``` js
-// 0. Si vous utilisez un système de module (ex : via vue-cli), il faut importer Vue et VueRouter et ensuite appeler `Vue.use(VueRouter)`.
+// 0. Si vous utilisez un système de module (par ex. via vue-cli), il faut importer Vue et Vue Router et ensuite appeler `Vue.use(VueRouter)`.
 
 // 1. Définissez les composants de route.
 // Ces derniers peuvent être importés depuis d'autre fichier


### PR DESCRIPTION
Hi @posva!

Something goes wrong with `essentials/getting-started.md`, line 33.

The options are: 

```
If using a module system (e.g. via vue-cli), import `Vue` and `VueRouter` 
```

*Speaking about Class name*

or

```
If using a module system (e.g. via vue-cli), import Vue and Vue Router
```

*Speaking about Product name*.

We have chosen to speak about Product name because the real Class syntax is given just after with `Vue.use(VueRouter)`.

I suggest that change in this PR.

What your thoughts about that?
