### PR TITLE
[en] typos

### DIFF
--- a/docs/en/advanced/lazy-loading.md
+++ b/docs/en/advanced/lazy-loading.md
@@ -44,4 +44,4 @@ const Bar = () => import(/* webpackChunkName: "group-foo" */ './Bar.vue')
 const Baz = () => import(/* webpackChunkName: "group-foo" */ './Baz.vue')
 ```
 
-Webpack will group any async module with the same chunk name into the same async chunk.
+webpack will group any async module with the same chunk name into the same async chunk.

--- a/docs/en/advanced/lazy-loading.md
+++ b/docs/en/advanced/lazy-loading.md
@@ -44,4 +44,4 @@ const Bar = () => import(/* webpackChunkName: "group-foo" */ './Bar.vue')
 const Baz = () => import(/* webpackChunkName: "group-foo" */ './Baz.vue')
 ```
 
-webpack will group any async module with the same chunk name into the same async chunk.
+Webpack will group any async module with the same chunk name into the same async chunk.

--- a/docs/en/essentials/history-mode.md
+++ b/docs/en/essentials/history-mode.md
@@ -43,24 +43,24 @@ location / {
 #### Native Node.js
 
 ```js
-const http = require("http")
-const fs = require("fs")
+const http = require('http')
+const fs = require('fs')
 const httpPort = 80
 
 http.createServer((req, res) => {
-  fs.readFile("index.htm", "utf-8", (err, content) => {
+  fs.readFile('index.htm', 'utf-8', (err, content) => {
     if (err) {
-      console.log('We cannot open "index.htm" file.')
+      console.log('We cannot open 'index.htm' file.')
     }
 
     res.writeHead(200, {
-      "Content-Type": "text/html; charset=utf-8"
+      'Content-Type': 'text/html; charset=utf-8'
     })
 
     res.end(content)
   })
 }).listen(httpPort, () => {
-  console.log("Server listening on: http://localhost:%s", httpPort)
+  console.log('Server listening on: http://localhost:%s', httpPort)
 })
 ```
 


### PR DESCRIPTION
Changes:

1. "webpack" -> "Webpack"
2. change double quotes into single quotes in code snippets about "native Node.js" in `history-mode.md`, just because the others all use single quotes.

Thanks.