### PR TITLE
Call scrollBehavior with app context

### DIFF
--- a/examples/scroll-behavior/app.js
+++ b/examples/scroll-behavior/app.js
@@ -25,23 +25,27 @@ const scrollBehavior = function (to, from, savedPosition) {
     // savedPosition is only available for popstate navigations.
     return savedPosition
   } else {
-    return new Promise(resolve => {
-      const position = {}
-      let delay = 500
-      // new navigation.
-      // scroll to anchor by returning the selector
-      if (to.hash) {
-        position.selector = to.hash
+    const position = {}
 
-        // specify offset of the element
-        if (to.hash === '#anchor2') {
-          position.offset = { y: 100 }
-        }
+    // scroll to anchor by returning the selector
+    if (to.hash) {
+      position.selector = to.hash
 
-        if (document.querySelector(to.hash)) {
-          delay = 0
-        }
+      // specify offset of the element
+      if (to.hash === '#anchor2') {
+        position.offset = { y: 100 }
       }
+
+      if (document.querySelector(to.hash)) {
+        return position
+      }
+
+      // if the returned position is falsy or an empty object,
+      // will retain current scroll position.
+      return false
+    }
+
+    return new Promise(resolve => {
       // check if any matched route config has meta that requires scrolling to top
       if (to.matched.some(m => m.meta.scrollToTop)) {
         // coords will be used if no selector is provided,
@@ -49,12 +53,13 @@ const scrollBehavior = function (to, from, savedPosition) {
         position.x = 0
         position.y = 0
       }
+
       // wait for the out transition to complete (if necessary)
-      setTimeout(() => {
-        // if the returned position is falsy or an empty object,
+      this.$root.$once('triggerScroll', () => {
+        // if the resolved position is falsy or an empty object,
         // will retain current scroll position.
         resolve(position)
-      }, delay)
+      })
     })
   }
 }
@@ -82,9 +87,14 @@ new Vue({
         <li><router-link to="/bar#anchor">/bar#anchor</router-link></li>
         <li><router-link to="/bar#anchor2">/bar#anchor2</router-link></li>
       </ul>
-      <transition name="fade" mode="out-in">
+      <transition name="fade" mode="out-in" @after-leave="afterLeave">
         <router-view class="view"></router-view>
       </transition>
     </div>
-  `
+  `,
+  methods: {
+    afterLeave () {
+      this.$root.$emit('triggerScroll')
+    }
+  }
 }).$mount('#app')

--- a/examples/scroll-behavior/app.js
+++ b/examples/scroll-behavior/app.js
@@ -55,7 +55,7 @@ const scrollBehavior = function (to, from, savedPosition) {
       }
 
       // wait for the out transition to complete (if necessary)
-      this.$root.$once('triggerScroll', () => {
+      this.app.$root.$once('triggerScroll', () => {
         // if the resolved position is falsy or an empty object,
         // will retain current scroll position.
         resolve(position)

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -39,7 +39,7 @@ export function handleScroll (
   // wait until re-render finishes before scrolling
   router.app.$nextTick(() => {
     const position = getScrollPosition()
-    const shouldScroll = behavior(to, from, isPop ? position : null)
+    const shouldScroll = behavior.call(router.app, to, from, isPop ? position : null)
 
     if (!shouldScroll) {
       return

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -39,7 +39,7 @@ export function handleScroll (
   // wait until re-render finishes before scrolling
   router.app.$nextTick(() => {
     const position = getScrollPosition()
-    const shouldScroll = behavior.call(router.app, to, from, isPop ? position : null)
+    const shouldScroll = behavior.call(router, to, from, isPop ? position : null)
 
     if (!shouldScroll) {
       return


### PR DESCRIPTION
This allows us to listen for events in the scroll behavior hook, thus enabling us to resolve a promise returned by the hook upon triggering of some custom event (for example one emited on the $root by an after-leave transition event).

```js
// in scrollBehavior
      this.$root.$once('triggerScroll', () => {
        resolve(position)
      })

// in component

  methods: {
    afterLeave () {
      this.$root.$emit('triggerScroll')
    }
  }
```
```html
<!-- in template -->
      <transition name="fade" mode="out-in" @after-leave="afterLeave">
        <router-view class="view"></router-view>
      </transition>
```

Sorry for hastily done PR.

Ref: https://github.com/nuxt/nuxt.js/issues/1376#issuecomment-336182111

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
