### PR TITLE
feat(scroll): use manual scrollRestoration with scrollBehavior

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -8,7 +8,7 @@ const positionStore = Object.create(null)
 
 export function setupScroll () {
   // Prevent browser scroll behavior on History popstate
-  window.history.scrollRestoration = 'manual';
+  window.history.scrollRestoration = 'manual'
   // Fix for #1585 for Firefox
   window.history.replaceState({ key: getStateKey() }, '')
   window.addEventListener('popstate', e => {

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -7,6 +7,8 @@ import { getStateKey, setStateKey } from './push-state'
 const positionStore = Object.create(null)
 
 export function setupScroll () {
+  // Prevent browser scroll behavior on History popstate
+  window.history.scrollRestoration = 'manual';
   // Fix for #1585 for Firefox
   window.history.replaceState({ key: getStateKey() }, '')
   window.addEventListener('popstate', e => {

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -8,7 +8,9 @@ const positionStore = Object.create(null)
 
 export function setupScroll () {
   // Prevent browser scroll behavior on History popstate
-  window.history.scrollRestoration = 'manual'
+  if ('scrollRestoration' in window.history) {
+    window.history.scrollRestoration = 'manual'
+  }
   // Fix for #1585 for Firefox
   window.history.replaceState({ key: getStateKey() }, '')
   window.addEventListener('popstate', e => {


### PR DESCRIPTION
Browser default to perform a scroll when popstate happens which cause a glitch especially when using vue-router async scroll.

`
window.history.scrollRestoration = 'manual';
`

Fix by adding this line.