### PR TITLE
fix(resolveAsyncComponents): return object when module is empty

### DIFF
--- a/src/util/resolve-components.js
+++ b/src/util/resolve-components.js
@@ -20,7 +20,7 @@ export function resolveAsyncComponents (matched: Array<RouteRecord>): Function {
         pending++
 
         const resolve = once(resolvedDef => {
-          if (isESModule(resolvedDef)) {
+          if (isESModule(resolvedDef) && resolvedDef.default) {
             resolvedDef = resolvedDef.default
           }
           // save resolved on async factory in case it's used elsewhere


### PR DESCRIPTION
When `resolvedDef.default` is `undefined`, `match.components[key]` will be `undefined` instead of a object like `{_Ctor: {},  inject: {}}` in v2.7.
I thought this behavior may break compatibility with previous versions, pls feel free to review and discuss.