### PR TITLE
chore: define the components using PascalCase

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -8,7 +8,7 @@ const toTypes: Array<Function> = [String, Object]
 const eventTypes: Array<Function> = [String, Array]
 
 export default {
-  name: 'router-link',
+  name: 'RouterLink',
   props: {
     to: {
       type: toTypes,

--- a/src/components/view.js
+++ b/src/components/view.js
@@ -1,7 +1,7 @@
 import { warn } from '../util/warn'
 
 export default {
-  name: 'router-view',
+  name: 'RouterView',
   functional: true,
   props: {
     name: {

--- a/src/install.js
+++ b/src/install.js
@@ -43,8 +43,8 @@ export function install (Vue) {
     get () { return this._routerRoot._route }
   })
 
-  Vue.component('router-view', View)
-  Vue.component('router-link', Link)
+  Vue.component('RouterView', View)
+  Vue.component('RouterLink', Link)
 
   const strats = Vue.config.optionMergeStrategies
   // use the same hook merging strategy for route hooks


### PR DESCRIPTION
- According to the [vue guide - Component Naming Conventions](https://vuejs.org/v2/guide/components.html#Component-Naming-Conventions):
  > This means that the PascalCase is the most universal declaration convention and kebab-case is the most universal usage convention.
- According to the [style guide - Component name casing in templates](https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended):
  > In most projects, component names should always be PascalCase in single-file components and string templates - but kebab-case in DOM templates.