### PR TITLE
Prevent banner from being removed by minifiers

### DIFF
--- a/build/configs.js
+++ b/build/configs.js
@@ -6,7 +6,7 @@ const node = require('rollup-plugin-node-resolve')
 const replace = require('rollup-plugin-replace')
 const version = process.env.VERSION || require('../package.json').version
 const banner =
-`/**
+`/*!
   * vue-router v${version}
   * (c) ${new Date().getFullYear()} Evan You
   * @license MIT


### PR DESCRIPTION
Trying to debug a webpack bundle splitting setup was made a bit trickier because it was hard to tell where this package was being included. Adding this should make the process a bit simpler.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
