### PR TITLE
webpack version detail in the doc

### DIFF
--- a/docs/zh-cn/advanced/lazy-loading.md
+++ b/docs/zh-cn/advanced/lazy-loading.md
@@ -10,7 +10,7 @@
 const Foo = () => Promise.resolve({ /* 组件定义对象 */ })
 ```
 
-第二，在 Webpack 2 中，我们可以使用[动态 import](https://github.com/tc39/proposal-dynamic-import)语法来定义代码分块点 (split point)：
+第二，在 Webpack 2.6+ 中，我们可以使用[动态 import](https://github.com/tc39/proposal-dynamic-import)语法来定义代码分块点 (split point)：
 
 ``` js
 import('./Foo.vue') // 返回 Promise


### PR DESCRIPTION
Webpack began after version 2.6 + support import dynamic module is introduced.

Novice in practice, these version details easily out of a big pit, after about tool version, please consider carefully, maintain the Vue community together😄

detail see site -->  https://webpack.js.org/api/module-methods/#import-

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
