### PR TITLE
Update to nginx example

### DIFF
--- a/docs/en/essentials/history-mode.md
+++ b/docs/en/essentials/history-mode.md
@@ -36,7 +36,7 @@ Not to worry: To fix the issue, all you need to do is add a simple catch-all fal
 
 ```nginx
 location / {
-  try_files $uri $uri/ /index.html;
+  try_files $uri /index.html $uri/ =404;
 }
 ```
 


### PR DESCRIPTION
If you have multiple `sites-enabled` on the same nginx server then setting `try_files $uri $uri/ /index.html;` causes a 500 error on the other sites if the first site root directory it tries is empty

https://serverfault.com/questions/505098/what-does-this-nginx-error-rewrite-or-internal-redirection-cycle-mean\?newreg\=96a16475fb24461b973b6c9bec2f4308

To support history fallback and make sure no other sites are affected  setting `try_files $uri /index.html $uri/ =404;` will route all requests to index. If it is not found, then it will serve a 404 error and avoid the infinite loop which causes other sites on the server to error and not load

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
