### PR TITLE
Add typing for async components

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -73,7 +73,7 @@ export interface PathToRegexpOptions {
 export interface RouteConfig {
   path: string;
   name?: string;
-  component?: Component;
+  component?: () => Promise<any> | Component;
   components?: Dictionary<Component>;
   redirect?: RedirectOption;
   alias?: string | string[];

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -73,7 +73,7 @@ export interface PathToRegexpOptions {
 export interface RouteConfig {
   path: string;
   name?: string;
-  component?: () => Promise<any> | Component;
+  component?: () => Promise<Component> | Component;
   components?: Dictionary<Component>;
   redirect?: RedirectOption;
   alias?: string | string[];


### PR DESCRIPTION
I think that this typing is necessary to work with async components.

`component: () => import('./cities.component')`
