### PR TITLE
fix(errors): added check if IE11 then use hashchange event listener F…

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -28,7 +28,10 @@ export class HashHistory extends History {
       setupScroll()
     }
 
-    window.addEventListener(supportsPushState ? 'popstate' : 'hashchange', () => {
+    const ua = window.navigator.userAgent
+    const ie11 = ua.indexOf('rv:11.0') !== -1
+
+    window.addEventListener(supportsPushState && !ie11 ? 'popstate' : 'hashchange', () => {
       const current = this.current
       if (!ensureSlash()) {
         return


### PR DESCRIPTION
fix #1849

IE11 does not fire the popstate event when the URL's hash value changes. Changed, in IE11 case, from `propstate` event listener to `hashchange`.