### PR TITLE
fix(match): use pathMatch for the param of * routes

### DIFF
--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -189,7 +189,8 @@ function matchRoute (
     const key = regex.keys[i - 1]
     const val = typeof m[i] === 'string' ? decodeURIComponent(m[i]) : m[i]
     if (key) {
-      params[key.name] = val
+      // Fix #1994: using * with props: true generates a param named 0
+      params[key.name || 'fullPath'] = val
     }
   }
 

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -190,7 +190,7 @@ function matchRoute (
     const val = typeof m[i] === 'string' ? decodeURIComponent(m[i]) : m[i]
     if (key) {
       // Fix #1994: using * with props: true generates a param named 0
-      params[key.name || 'fullPath'] = val
+      params[key.name || 'pathMatch'] = val
     }
   }
 

--- a/test/e2e/specs/route-matching.js
+++ b/test/e2e/specs/route-matching.js
@@ -83,7 +83,7 @@ module.exports = {
           route.matched[0].path === '/asterisk/*' &&
           route.fullPath === '/asterisk/foo' &&
           JSON.stringify(route.params) === JSON.stringify({
-            0: 'foo'
+            'fullPath': 'foo'
           })
         )
       }, null, '/asterisk/foo')
@@ -96,7 +96,7 @@ module.exports = {
           route.matched[0].path === '/asterisk/*' &&
           route.fullPath === '/asterisk/foo/bar' &&
           JSON.stringify(route.params) === JSON.stringify({
-            0: 'foo/bar'
+            'fullPath': 'foo/bar'
           })
         )
       }, null, '/asterisk/foo/bar')

--- a/test/e2e/specs/route-matching.js
+++ b/test/e2e/specs/route-matching.js
@@ -83,7 +83,7 @@ module.exports = {
           route.matched[0].path === '/asterisk/*' &&
           route.fullPath === '/asterisk/foo' &&
           JSON.stringify(route.params) === JSON.stringify({
-            'fullPath': 'foo'
+            pathMatch: 'foo'
           })
         )
       }, null, '/asterisk/foo')
@@ -96,7 +96,7 @@ module.exports = {
           route.matched[0].path === '/asterisk/*' &&
           route.fullPath === '/asterisk/foo/bar' &&
           JSON.stringify(route.params) === JSON.stringify({
-            'fullPath': 'foo/bar'
+            pathMatch: 'foo/bar'
           })
         )
       }, null, '/asterisk/foo/bar')
@@ -120,7 +120,7 @@ module.exports = {
           route.matched[0].path === '/optional-group/(foo/)?bar' &&
           route.fullPath === '/optional-group/foo/bar' &&
           JSON.stringify(route.params) === JSON.stringify({
-            0: 'foo/'
+            pathMatch: 'foo/'
           })
         )
       }, null, '/optional-group/foo/bar')

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -3,7 +3,7 @@ import { createMatcher } from '../../../src/create-matcher'
 
 const routes = [
   { path: '/', name: 'home', component: { name: 'home' }},
-  { path: '/foo', name: 'foo', component: { name: 'foo' }},
+  { path: '/foo', name: 'foo', component: { name: 'foo' }}
 ]
 
 describe('Creating Matcher', function () {

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -3,7 +3,8 @@ import { createMatcher } from '../../../src/create-matcher'
 
 const routes = [
   { path: '/', name: 'home', component: { name: 'home' }},
-  { path: '/foo', name: 'foo', component: { name: 'foo' }}
+  { path: '/foo', name: 'foo', component: { name: 'foo' }},
+  { path: '*', props: true, component: { name: 'notFound' }}
 ]
 
 describe('Creating Matcher', function () {
@@ -31,5 +32,10 @@ describe('Creating Matcher', function () {
   it('in production, it has not logged this warning', function () {
     match({ name: 'foo' }, routes[0])
     expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('matches asterisk routes with fullName as the param', function () {
+    const { params } = match({ path: '/not-found' }, routes[0])
+    expect(params).toEqual({ fullPath: '/not-found' })
   })
 })

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -34,8 +34,8 @@ describe('Creating Matcher', function () {
     expect(console.warn).not.toHaveBeenCalled()
   })
 
-  it('matches asterisk routes with fullName as the param', function () {
+  it('matches asterisk routes with a default param name', function () {
     const { params } = match({ path: '/not-found' }, routes[0])
-    expect(params).toEqual({ fullPath: '/not-found' })
+    expect(params).toEqual({ pathMatch: '/not-found' })
   })
 })


### PR DESCRIPTION
Fix #1994
Combining an asterisk route (*) with props: true would result in an
error because the name of the param would be the number 0 making it an
invalid attribute + the fact that vue passes props as attributes
if they're not declared as props

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
