### PR TITLE
Mask for urls

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -47,7 +47,18 @@ export class HashHistory extends History {
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
     this.transitionTo(location, route => {
-      pushHash(route.fullPath)
+      let fullPath = route.fullPath
+      
+      this.ninja = undefined
+      if (location.ninjaPath && location.ninjaPath !== route.fullPath) {
+        fullPath = location.ninjaPath
+        this.ninja = {
+          ninjaPath : location.ninjaPath,
+          realPath : route.fullPath,
+        }
+      }
+
+      pushHash(fullPath)
       handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)
@@ -56,7 +67,18 @@ export class HashHistory extends History {
   replace (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
     this.transitionTo(location, route => {
-      replaceHash(route.fullPath)
+      let fullPath = route.fullPath
+      
+      this.ninja = undefined
+      if (location.ninjaPath && location.ninjaPath !== route.fullPath) {
+        fullPath = location.ninjaPath
+        this.ninja = {
+          ninjaPath : location.ninjaPath,
+          realPath : route.fullPath,
+        }
+      }
+      
+      replaceHash(fullPath)
       handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)
@@ -67,8 +89,15 @@ export class HashHistory extends History {
   }
 
   ensureURL (push?: boolean) {
+    const location = getHash()
     const current = this.current.fullPath
-    if (getHash() !== current) {
+    if (location !== current
+        && (!this.ninja || (this.ninja && location !== this.ninja.ninjaPath))
+    ) {
+      if (this.ninja && this.ninja.realPath === current) {
+        current = this.ninja.ninjaPath
+      }
+      
       push ? pushHash(current) : replaceHash(current)
     }
   }

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -44,7 +44,18 @@ export class HTML5History extends History {
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
     this.transitionTo(location, route => {
-      pushState(cleanPath(this.base + route.fullPath))
+      let fullPath = route.fullPath
+
+      this.ninja = undefined
+      if (location.ninjaPath && location.ninjaPath !== route.fullPath) {
+        fullPath = location.ninjaPath
+        this.ninja = {
+          ninjaPath : location.ninjaPath,
+          realPath : route.fullPath,
+        }
+      }
+
+      pushState(cleanPath(this.base + fullPath))
       handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)
@@ -53,15 +64,35 @@ export class HTML5History extends History {
   replace (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
     this.transitionTo(location, route => {
-      replaceState(cleanPath(this.base + route.fullPath))
+      let fullPath = route.fullPath
+      
+      this.ninja = undefined
+      if (location.ninjaPath && location.ninjaPath !== route.fullPath) {
+        fullPath = location.ninjaPath
+        this.ninja = {
+          ninjaPath : location.ninjaPath,
+          realPath : route.fullPath,
+        }
+      }
+
+      replaceState(cleanPath(this.base + fullPath));
       handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)
   }
 
   ensureURL (push?: boolean) {
-    if (getLocation(this.base) !== this.current.fullPath) {
-      const current = cleanPath(this.base + this.current.fullPath)
+    const location = getLocation(this.base)
+    if (location !== this.current.fullPath
+        && (!this.ninja || (this.ninja && location !== this.ninja.ninjaPath))
+    ) {
+      let fullPath = this.current.fullPath
+
+      if (this.ninja && this.ninja.realPath === this.current.fullPath) {
+        fullPath = this.ninja.ninjaPath
+      }
+
+      const current = cleanPath(this.base + fullPath);
       push ? pushState(current) : replaceState(current)
     }
   }


### PR DESCRIPTION
Related issue #1858 

Adding support to hide real path by 'ninja' mask
Pass object with 'ninjaPath' property to 'push' or 'replace' method, 'ninjaPath' will be displayed in address bar.

Use case:
Dynamic short urls like 'domain/fancyShortUrl' which will be caught in '*' route and lead to 'domain/user/userId' or 'domain/note/noteId' based on response from server, but URL in address bar will remain 'domain/fancyShortUrl'

ps. I'm beginner.