### PR TITLE
Throw error when component is undefined or null (#2038)

### DIFF
--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -57,6 +57,10 @@ function addRouteRecord (
       `route config "component" for path: ${String(path || name)} cannot be a ` +
       `string id. Use an actual component instead.`
     )
+    assert(
+      route.component !== null && route.component !== undefined,
+      `route config "component" for path: ${String(path || name)} cannot be ${String(route.component)}.`
+    )
   }
 
   const pathToRegexpOptions: PathToRegexpOptions = route.pathToRegexpOptions || {}

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -58,7 +58,7 @@ function addRouteRecord (
       `string id. Use an actual component instead.`
     )
     assert(
-      route.component !== null && route.component !== undefined,
+      route.component,
       `route config "component" for path: ${String(path || name)} cannot be ${String(route.component)}.`
     )
   }

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -47,7 +47,8 @@ function addRouteRecord (
   nameMap: Dictionary<RouteRecord>,
   route: RouteConfig,
   parent?: RouteRecord,
-  matchAs?: string
+  matchAs?: string,
+  isAnAlias?: boolean
 ) {
   const { path, name } = route
   if (process.env.NODE_ENV !== 'production') {
@@ -57,9 +58,11 @@ function addRouteRecord (
       `route config "component" for path: ${String(path || name)} cannot be a ` +
       `string id. Use an actual component instead.`
     )
-    assert(
-      route.component,
-      `route config "component" for path: ${String(path || name)} cannot be ${String(route.component)}.`
+    warn(
+      route.component || route.components || route.redirect || route.beforeEnter || isAnAlias,
+      `route config "component" for path: ${String(path || name)} should be either a ` +
+      `component (or named component), redirection, navigation guard, or an alias ` +
+      `to another root.`
     )
   }
 
@@ -132,7 +135,8 @@ function addRouteRecord (
         nameMap,
         aliasRoute,
         parent,
-        record.path || '/' // matchAs
+        record.path || '/', // matchAs
+        true
       )
     })
   }

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -80,9 +80,8 @@ describe('Creating Route Map', function () {
 
   it('in development, throws if component is null or undefined', function () {
     process.env.NODE_ENV = 'development'
-    expect(() => {
-      maps = createRouteMap([{ path: '/' }])
-    }).toThrowError(/route config "component" for path/)
+    maps = createRouteMap([{ path: '/' }])
+    expect(console.warn).toHaveBeenCalled()
   })
 
   it('in production, it has not logged this warning', function () {

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -78,6 +78,13 @@ describe('Creating Route Map', function () {
     }).toThrowError(/"path" is required/)
   })
 
+  it('in development, throws if component is null or undefined', function () {
+    process.env.NODE_ENV = 'development'
+    expect(() => {
+      maps = createRouteMap([{ path: '/' }])
+    }).toThrowError(/route config "component" for path/)
+  })
+
   it('in production, it has not logged this warning', function () {
     maps = createRouteMap(routes)
     expect(console.warn).not.toHaveBeenCalled()


### PR DESCRIPTION
Add assertion when a route component is null or undefined, a fix for issue #2038.

Really appreciate for a review.