### PR TITLE
Update docs to expose redirectedFrom on $route object

### DIFF
--- a/docs/en/api/route-object.md
+++ b/docs/en/api/route-object.md
@@ -90,4 +90,4 @@ The route object can be found in multiple places:
 
 - **$route.redirectedFrom**
 
-  The name of the route being redirected from, if it there were one. (See [Redirect and Alias](../essentials/redirect-and-alias.md))
+  The name of the route being redirected from, if there were one. (See [Redirect and Alias](../essentials/redirect-and-alias.md))

--- a/docs/en/api/route-object.md
+++ b/docs/en/api/route-object.md
@@ -87,3 +87,7 @@ The route object can be found in multiple places:
 - **$route.name**
 
   The name of the current route, if it has one. (See [Named Routes](../essentials/named-routes.md))
+
+- **$route.redirectedFrom**
+
+  The name of the route being redirected from, if it there were one. (See [Redirect and Alias](../essentials/redirect-and-alias.md))

--- a/docs/en/essentials/redirect-and-alias.md
+++ b/docs/en/essentials/redirect-and-alias.md
@@ -37,6 +37,8 @@ const router = new VueRouter({
 
 Note that [Navigation Guards](../advanced/navigation-guards.md) are not applied on the route that redirects, only on its target. In the example below, adding a `beforeEnter` or `beforeLeave` guard to the `/a` route would not have any effect.
 
+[Meta fields](../advanced/meta.md) and [props](passing-props.md) are ignored if specified on a redirect route definition
+
 For other advanced usage, checkout the [example](https://github.com/vuejs/vue-router/blob/dev/examples/redirect/app.js).
 
 ### Alias

--- a/docs/en/essentials/redirect-and-alias.md
+++ b/docs/en/essentials/redirect-and-alias.md
@@ -37,8 +37,6 @@ const router = new VueRouter({
 
 Note that [Navigation Guards](../advanced/navigation-guards.md) are not applied on the route that redirects, only on its target. In the example below, adding a `beforeEnter` or `beforeLeave` guard to the `/a` route would not have any effect.
 
-[Meta fields](../advanced/meta.md) and [props](passing-props.md) are ignored if specified on a redirect route definition
-
 For other advanced usage, checkout the [example](https://github.com/vuejs/vue-router/blob/dev/examples/redirect/app.js).
 
 ### Alias


### PR DESCRIPTION
This PR describes the `vm.$route.redirectedFrom` property that is made available if the current route is the result of a redirect.
It also updates the docs to clarify that props and meta fields are ignored for redirect route definitions.