### PR TITLE
this.$router标题有误

### DIFF
--- a/docs/zh-cn/essentials/getting-started.md
+++ b/docs/zh-cn/essentials/getting-started.md
@@ -63,7 +63,7 @@ const app = new Vue({
 // 现在，应用已经启动了！
 ```
 
-通过注入路由，我们可以用 `this.$route` 来访问它，就像在任何组件里用 `this.$route` 访问当前路由一样。
+通过注入路由器，我们可以在任何组件内通过 `this.$router` 访问路由器，也可以通过 `this.$route` 访问当前路由：
 
 ```js
 // Home.vue

--- a/docs/zh-cn/essentials/getting-started.md
+++ b/docs/zh-cn/essentials/getting-started.md
@@ -63,7 +63,7 @@ const app = new Vue({
 // 现在，应用已经启动了！
 ```
 
-通过注入路由，我们可以用 `this.$router` 来访问它，就像在任何组件里用 `this.$router` 访问当前路由一样。
+通过注入路由，我们可以用 `this.$route` 来访问它，就像在任何组件里用 `this.$route` 访问当前路由一样。
 
 ```js
 // Home.vue


### PR DESCRIPTION
在组件中访问当前路由使用this.$route，页面中标题写的是this.$router

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
