### PR TITLE
Query/Location can be an array of strings. (fix #1932)

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -107,7 +107,7 @@ export interface Location {
   name?: string;
   path?: string;
   hash?: string;
-  query?: Dictionary<string>;
+  query?: Dictionary<string | string[]>;
   params?: Dictionary<string>;
   append?: boolean;
   replace?: boolean;
@@ -117,7 +117,7 @@ export interface Route {
   path: string;
   name?: string;
   hash: string;
-  query: Dictionary<string>;
+  query: Dictionary<string | string[]>;
   params: Dictionary<string>;
   fullPath: string;
   matched: RouteRecord[];

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -105,7 +105,7 @@ const route: Route = router.currentRoute;
 const path: string = route.path;
 const name: string | undefined = route.name;
 const hash: string = route.hash;
-const query: string = route.query["foo"];
+const query: string | string[] = route.query["foo"];
 const params: string = route.params["bar"];
 const fullPath: string = route.fullPath;
 const redirectedFrom: string | undefined = route.redirectedFrom;
@@ -148,7 +148,8 @@ router.push({
     foo: "foo"
   },
   query: {
-    bar: "bar"
+    bar: "bar",
+    foo: ["foo1", "foo2"]
   },
   hash: "hash"
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Query and Location can be arrays as can be deduced from a spec [here](https://github.com/vuejs/vue-router/blob/dev/test/unit/specs/query.spec.js#L6-L8) and [here](https://github.com/vuejs/vue-router/blob/dev/test/unit/specs/query.spec.js#L19-L20).

I guess for custom parsing user needs to provide own types and override ones coming from router somehow.