### PR TITLE
Navigate when a new route is added while on a wildcard

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -100,7 +100,8 @@ export class History {
     if (
       isSameRoute(route, current) &&
       // in the case the route map has been dynamically appended to
-      route.matched.length === current.matched.length
+      route.matched.length === current.matched.length &&
+      route.matched[0] === current.matched[0]
     ) {
       this.ensureURL()
       return abort()


### PR DESCRIPTION
As I am also relying on having dynamically added routes and a fallback 404 route, I tried fixing #1862 by checking not only if the matched routes length changed but also if the matched route itself changed:
`route.matched[0] === current.matched[0]`

Is this a valid way to fix this issue? Or do we have to check if there is more than one matched route?

Closes #1862 