### PR TITLE
Dynamically add child routes to an existing route #1156

### DIFF
--- a/examples/nested-routes/app.js
+++ b/examples/nested-routes/app.js
@@ -53,9 +53,6 @@ const router = new VueRouter({
         // components rendered at /parent/foo: Root -> Parent -> Foo
         { path: 'foo', component: Foo },
 
-        // components rendered at /parent/bar: Root -> Parent -> Bar
-        { path: 'bar', component: Bar },
-
         // NOTE absolute path here!
         // this allows you to leverage the component nesting without being
         // limited to the nested URL.
@@ -67,8 +64,6 @@ const router = new VueRouter({
           component: Qux,
           children: [{ path: 'quux', name: 'quux', component: Quux }]
         },
-
-        { path: 'quy/:quyId', component: Quy },
 
         { name: 'zap', path: 'zap/:zapId?', component: Zap }
       ]
@@ -96,3 +91,8 @@ new Vue({
     </div>
   `
 }).$mount('#app')
+
+router.addRoutes([
+  { path: 'bar', component: Bar, parent: '/parent' },
+  { path: 'quy/:quyId', component: Quy, parent: '/parent' }
+])

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -49,6 +49,7 @@ function addRouteRecord (
   parent?: RouteRecord,
   matchAs?: string
 ) {
+  const parentPath = pathMap[String(route.parent || null)] || parent
   const { path, name } = route
   if (process.env.NODE_ENV !== 'production') {
     assert(path != null, `"path" is required in a route configuration.`)
@@ -61,7 +62,7 @@ function addRouteRecord (
   const pathToRegexpOptions: PathToRegexpOptions = route.pathToRegexpOptions || {}
   const normalizedPath = normalizePath(
     path,
-    pathMap[route.parent] || parent,
+    parentPath,
     pathToRegexpOptions.strict
   )
 
@@ -74,7 +75,7 @@ function addRouteRecord (
     components: route.components || { default: route.component },
     instances: {},
     name,
-    parent: pathMap[route.parent] || parent,
+    parent: parentPath,
     matchAs,
     redirect: route.redirect,
     beforeEnter: route.beforeEnter,
@@ -125,7 +126,7 @@ function addRouteRecord (
         pathMap,
         nameMap,
         aliasRoute,
-        pathMap[route.parent] || parent,
+        parentPath,
         record.path || '/' // matchAs
       )
     })

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -58,25 +58,23 @@ function addRouteRecord (
       `string id. Use an actual component instead.`
     )
   }
-
   const pathToRegexpOptions: PathToRegexpOptions = route.pathToRegexpOptions || {}
   const normalizedPath = normalizePath(
     path,
-    parent,
+    pathMap[route.parent] || parent,
     pathToRegexpOptions.strict
   )
 
   if (typeof route.caseSensitive === 'boolean') {
     pathToRegexpOptions.sensitive = route.caseSensitive
   }
-
   const record: RouteRecord = {
     path: normalizedPath,
     regex: compileRouteRegex(normalizedPath, pathToRegexpOptions),
     components: route.components || { default: route.component },
     instances: {},
     name,
-    parent,
+    parent: pathMap[route.parent] || parent,
     matchAs,
     redirect: route.redirect,
     beforeEnter: route.beforeEnter,
@@ -127,7 +125,7 @@ function addRouteRecord (
         pathMap,
         nameMap,
         aliasRoute,
-        parent,
+        pathMap[route.parent] || parent,
         record.path || '/' // matchAs
       )
     })

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -49,7 +49,7 @@ function addRouteRecord (
   parent?: RouteRecord,
   matchAs?: string
 ) {
-  const parentPath = pathMap[String(route.parent || null)] || parent
+  const parentPath = (nameMap[String(route.parent || null)] || pathMap[String(route.parent || null)]) || parent
   const { path, name } = route
   if (process.env.NODE_ENV !== 'production') {
     assert(path != null, `"path" is required in a route configuration.`)

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -52,11 +52,13 @@ describe('router.addRoutes', () => {
         { path: '/a', component: { name: 'A' }},
         {
           path: '/a1',
+          name: 'A1ComponentName',
           component: { name: 'A1' },
           children: [
             {
               path: '/b1',
-              component: { name: 'B1' }
+              component: { name: 'B1' },
+              name: 'B1ComponentName'
             }
           ]
         }
@@ -117,6 +119,19 @@ describe('router.addRoutes', () => {
     expect(components.length).toBe(2)
     expect(components[0].name).toBe('B')
     expect(components[1].name).toBe('C')
+
+    // nested routes asociate to parent name route
+    router.push('/d')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(0)
+
+    router.addRoutes([
+      { path: '/d', component: { name: 'D' }, parent: 'A1ComponentName' }
+    ])
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(2)
+    expect(components[0].name).toBe('A1')
+    expect(components[1].name).toBe('D')
 
   })
 })

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -49,7 +49,17 @@ describe('router.addRoutes', () => {
     const router = new Router({
       mode: 'abstract',
       routes: [
-        { path: '/a', component: { name: 'A' }}
+        { path: '/a', component: { name: 'A' }},
+        {
+          path: '/a1',
+          component: { name: 'A1' },
+          children: [
+            {
+              path: '/b1',
+              component: { name: 'B1' }
+            }
+          ]
+        }
       ]
     })
 
@@ -74,6 +84,40 @@ describe('router.addRoutes', () => {
     components = router.getMatchedComponents()
     expect(components.length).toBe(1)
     expect(components[0].name).toBe('A')
+
+    // nested routes existing children relation
+
+    router.push('/b1')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(2)
+    expect(components[0].name).toBe('A1')
+    expect(components[1].name).toBe('B1')
+
+    router.addRoutes([
+      { path: '/c1', component: { name: 'C1' }, parent: '/b1' }
+    ])
+
+    // nested routes dynamic children relation
+
+    router.push('/c1')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(3)
+    expect(components[0].name).toBe('A1')
+    expect(components[1].name).toBe('B1')
+    expect(components[2].name).toBe('C1')
+
+    router.push('/c')
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(0)
+
+    router.addRoutes([
+      { path: '/c', component: { name: 'C' }, parent: '/b' }
+    ])
+    components = router.getMatchedComponents()
+    expect(components.length).toBe(2)
+    expect(components[0].name).toBe('B')
+    expect(components[1].name).toBe('C')
+
   })
 })
 

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -79,6 +79,7 @@ export interface RouteConfig {
   alias?: string | string[];
   children?: RouteConfig[];
   meta?: any;
+  parent?: string;
   beforeEnter?: NavigationGuard;
   props?: boolean | Object | RoutePropsFunction;
   caseSensitive?: boolean;


### PR DESCRIPTION
Reason:
we need to add dynamic routes that are associated with a parent.

Unit Test:
router.addRoutes - from line "nested routes existing children relation".

Excuse me if this PR does not meet the guidelines, is my first PR in OpenSource.

Thanks!