### PR TITLE
[Typings] Add this.$router.options

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -18,6 +18,7 @@ export declare class VueRouter {
   app: Vue;
   mode: RouterMode;
   currentRoute: Route;
+  options: RouterOptions;
 
   beforeEach (guard: NavigationGuard): Function;
   beforeResolve (guard: NavigationGuard): Function;


### PR DESCRIPTION
There is a time when a user wants to access metadata that was defined in `router.ts` ([example](https://github.com/DrSensor/F.I.D.E/blob/develop/src/renderer/components/NavigationSidebar.vue#L93)). I notice that in the typedef `options` is missing.

![screenshot from 2018-03-01 12-16-59](https://user-images.githubusercontent.com/4953069/36828284-6ed0e5d8-1d4b-11e8-9dc6-0a62c005c384.png)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
