### PR TITLE
Add support for 'disabled' attribute to <router-link>, fixes #916

### DIFF
--- a/examples/navigation-guards/app.js
+++ b/examples/navigation-guards/app.js
@@ -87,6 +87,14 @@ const Quux = {
   }
 }
 
+const Baf = {
+  template: `
+    <div>
+      <p> baf, you should never see this</p>
+    </div>
+  `
+}
+
 const router = new VueRouter({
   mode: 'history',
   base: __dirname,
@@ -106,7 +114,7 @@ const router = new VueRouter({
     // Qux implements an in-component beforeRouteEnter hook
     { path: '/qux', component: Qux },
 
-   // in-component beforeRouteEnter hook for async components
+    // in-component beforeRouteEnter hook for async components
     { path: '/qux-async', component: resolve => {
       setTimeout(() => {
         resolve(Qux)
@@ -114,7 +122,11 @@ const router = new VueRouter({
     } },
 
     // in-component beforeRouteUpdate hook
-    { path: '/quux/:id', component: Quux }
+    { path: '/quux/:id', component: Quux },
+
+    // Baf implements declarative "disabled" in template
+    { path: '/baf', component: Baf }
+
   ]
 })
 
@@ -140,6 +152,7 @@ new Vue({
         <li><router-link to="/qux-async">/qux-async</router-link></li>
         <li><router-link to="/quux/1">/quux/1</router-link></li>
         <li><router-link to="/quux/2">/quux/2</router-link></li>
+        <li><router-link to="/baf" disabled>/baf</router-link></li>
       </ul>
       <router-view class="view"></router-view>
     </div>

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -119,6 +119,11 @@ function guardEvent (e) {
   if (e.preventDefault) {
     e.preventDefault()
   }
+  // if the currentTarget is disabled, preventDefault, don't redirect
+  if (e.currentTarget && e.currentTarget.getAttribute('disabled')) {
+    e.preventDefault && e.preventDefault()
+    return
+  }
   return true
 }
 

--- a/test/e2e/specs/navigation-guards.js
+++ b/test/e2e/specs/navigation-guards.js
@@ -8,8 +8,13 @@ module.exports = {
     browser
     .url('http://localhost:8080/navigation-guards/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 8)
+      .assert.count('li a', 9)
       .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(9) a')
+      .waitFor(100)
+      .assert.urlEquals('http://localhost:8080/navigation-guards/')
+      .assert.containsText('.view', 'home')      
 
       .click('li:nth-child(2) a')
       .dismissAlert()


### PR DESCRIPTION
During the discussion on #916 a solution was mentioned, where attribute `disabled` in `<router-link>` would prevent the link from working. This is useful for programmatically disabling router links based on application state. 

Compared to other solutions, both available and proposed, this is by far the cleanest and most idiomatic if you come from a HTML mindset, as it's available on form elements with the same purpose, and some CSS frameworks like Bootstrap promote its use for `<li><a>` navigation elements. 

Furthermore, binding to disabled attribute is a simple, easy to style and implement, and I honestly believe that for these reasons, it is also very idiomatic to Vue.js as well.

This pull request implements that proposal.