### PR TITLE
chore(package.json): add sideEffects: false field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
   "module": "dist/vue-router.esm.js",
   "unpkg": "dist/vue-router.js",
   "jsdelivr": "dist/vue-router.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/vuejs/vue-router.git"
   },
   "typings": "types/index.d.ts",
   "files": [
+    "src/*.js",
     "dist/*.js",
     "types/*.d.ts"
   ],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This PR adds the `"sideEffects": false` property in vue-router's `package.json` file. This allow's webpack (for those who want to opt-in to requiring vue-routers's original source files (instead of the flattened esm bundles) and want to remove flow type through a babel-transform, then this will allow webpack to aggressively ignore and treeshake unused exports throughout the module system (if they exist!)

In many cases this can yield hidden and surprising build time improvements and size reductions in the case that modules flattened from rollup aren't actually needed when webpack performs a scope analysis. 

The angular team has adopted this approach for the CLI yielding some strong build time speed for webpack (since unused exports are also not resolved, parsed, etc.). From my assessment of the module graph created, it looks that there are no sideEffects created against existing re-exports throughout the codebase, therefore even if a user did opt in on their own will, and remove flow types, there should be no danger of removing code that is needed and causing breakages. 

Overall, this already will not be a breaking change in any way but just provides extra benefits to those (and for the cli (if realized) when using webpack 4 and `mode: production`).

Happy to answer any other questions.
~Sean + [webpack team](https://github.com/webpack) 