### PR TITLE
Fix "#" placed incorrectly when query string is present on load (#2125)

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -108,8 +108,15 @@ export function getHash (): string {
 function getUrl (path) {
   const href = window.location.href
   const i = href.indexOf('#')
-  const base = i >= 0 ? href.slice(0, i) : href
-  return `${base}#${path}`
+  let base = i >= 0 ? href.slice(0, i) : href
+  let query = ''
+  // If query string is present in URL, place it after the hash path
+  if (href.indexOf('?') >= 0) {
+    const j = href.indexOf('?')
+    base = base.slice(0, j)
+    query = href.slice(j)
+  }
+  return `${base}#${path}${query}`
 }
 
 function pushHash (path) {

--- a/test/e2e/specs/hash-mode.js
+++ b/test/e2e/specs/hash-mode.js
@@ -1,7 +1,7 @@
 module.exports = {
   'Hash mode': function (browser) {
     browser
-    .url('http://localhost:8080/hash-mode/')
+    .url('http://localhost:8080/hash-mode/?foo=bar')
       .waitForElementVisible('#app', 1000)
       .assert.count('li', 4)
       .assert.count('li a', 3)
@@ -11,19 +11,19 @@ module.exports = {
       .assert.containsText('.view', 'home')
 
       .click('li:nth-child(2) a')
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/foo')
+      .assert.urlEquals('http://localhost:8080/hash-mode/#/foo?foo=bar')
       .assert.containsText('.view', 'foo')
 
       .click('li:nth-child(3) a')
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/bar')
+      .assert.urlEquals('http://localhost:8080/hash-mode/#/bar?foo=bar')
       .assert.containsText('.view', 'bar')
 
       .click('li:nth-child(1) a')
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/')
+      .assert.urlEquals('http://localhost:8080/hash-mode/#/?foo=bar')
       .assert.containsText('.view', 'home')
 
       .click('li:nth-child(4)')
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/bar')
+      .assert.urlEquals('http://localhost:8080/hash-mode/#/bar?foo=bar')
       .assert.containsText('.view', 'bar')
 
     // check initial visit


### PR DESCRIPTION
When navigating to a URL with a query string like `myapp.com?foo=bar` in hash mode, the hash is currently placed after the query string `myapp.com?foo=bar#/`

This fix correctly parses URLs with query strings so that the above URL will be `myapp.com/#/?foo=bar` after loading.