### PR TITLE
chore: init AbstractHistory for native app usage

### DIFF
--- a/src/history/abstract.js
+++ b/src/history/abstract.js
@@ -2,6 +2,7 @@
 
 import type Router from '../index'
 import { History } from './base'
+import { START } from '../util/route'
 
 export class AbstractHistory extends History {
   index: number;
@@ -9,8 +10,14 @@ export class AbstractHistory extends History {
 
   constructor (router: Router, base: ?string) {
     super(router, base)
-    this.stack = []
-    this.index = -1
+    const defaultRoute = this.router.match(START.path, this.current)
+    if (defaultRoute.matched.length) {
+      this.stack = [defaultRoute]
+      this.index = 0
+    } else {
+      this.stack = []
+      this.index = -1
+    }
   }
 
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,8 @@ export default class VueRouter {
         setupHashListener,
         setupHashListener
       )
+    } else if (history instanceof AbstractHistory && history.stack.length > -1) {
+      history.transitionTo(history.getCurrentLocation())
     }
 
     history.listen(route => {


### PR DESCRIPTION
Initial AbstractHistory with "/" path, so that vue-router could be running in special environments, such as in Native app mode.

The problem is in the go[1] method, original implementation makes go(-1) can't work correctly. 

[1] https://github.com/vuejs/vue-router/blob/dev/src/history/abstract.js#L31