### PR TITLE
fix: go(-1) for AbstractHistory by initial stack

### DIFF
--- a/src/history/abstract.js
+++ b/src/history/abstract.js
@@ -2,6 +2,7 @@
 
 import type Router from '../index'
 import { History } from './base'
+import { START } from '../util/route'
 
 export class AbstractHistory extends History {
   index: number;
@@ -9,8 +10,14 @@ export class AbstractHistory extends History {
 
   constructor (router: Router, base: ?string) {
     super(router, base)
-    this.stack = []
-    this.index = -1
+    const defaultRoute = this.router.match(START.path, this.current)
+    if (defaultRoute.matched.length) {
+      this.stack = [defaultRoute]
+      this.index = 0
+    } else {
+      this.stack = []
+      this.index = -1
+    }
   }
 
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,8 @@ export default class VueRouter {
         setupHashListener,
         setupHashListener
       )
+    } else if (history instanceof AbstractHistory && history.stack.length > 0) {
+      history.transitionTo(history.getCurrentLocation())
     }
 
     history.listen(route => {


### PR DESCRIPTION
In the original implementation, stack of AbstractHistory was initialized by empty array, it makes go(-1)[1] can't work correctly.

In most situation that can't go back, it doesn't matter, but in a special environment(such as running in JavascriptCore of Native App), go(-1) can't work will be a bug.

The problem is I haven't tested in SSR, the patch may break something, a better NodeJS determine method is required.

[1] https://github.com/vuejs/vue-router/blob/dev/src/history/abstract.js#L31 