### PR TITLE
fix initial url path for non ascii urls

### DIFF
--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -72,7 +72,7 @@ export class HTML5History extends History {
 }
 
 export function getLocation (base: string): string {
-  let path = window.location.pathname
+  let path = decodeURIComponent(window.location.pathname)
   if (base && path.indexOf(base) === 0) {
     path = path.slice(base.length)
   }

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -72,7 +72,7 @@ export class HTML5History extends History {
 }
 
 export function getLocation (base: string): string {
-  let path = decodeURIComponent(window.location.pathname)
+  let path = decodeURI(window.location.pathname)
   if (base && path.indexOf(base) === 0) {
     path = path.slice(base.length)
   }


### PR DESCRIPTION
Here is demo of issue https://codesandbox.io/s/m2xnyj5zx

If click links withing app - active class applies fine for both links
If load page on /hello - active class applies to hello link fine
If load page on /тест - active class applies not applied to /тест link and the component not loaded

The problem is because on initial load vue-router use window.location.pathname for path, which is uri encoded, so it wont match routes because they are not uri encoded.