### PR TITLE
Added resolving a component type.

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -6,10 +6,10 @@ type Dictionary<T> = { [key: string]: T };
 export type RouterMode = "hash" | "history" | "abstract";
 export type RawLocation = string | Location;
 export type RedirectOption = RawLocation | ((to: Route) => RawLocation);
-export type NavigationGuard = (
+export type NavigationGuard<V extends Vue = Vue> = (
   to: Route,
   from: Route,
-  next: (to?: RawLocation | false | ((vm: Vue) => any) | void) => void
+  next: (to?: RawLocation | false | ((vm: V) => any) | void) => void
 ) => any
 
 export declare class VueRouter {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -15,8 +15,8 @@ declare module "vue/types/vue" {
 declare module "vue/types/options" {
   interface ComponentOptions<V extends Vue> {
     router?: VueRouter;
-    beforeRouteEnter?: NavigationGuard;
-    beforeRouteLeave?: NavigationGuard;
-    beforeRouteUpdate?: NavigationGuard;
+    beforeRouteEnter?: NavigationGuard<V>;
+    beforeRouteLeave?: NavigationGuard<V>;
+    beforeRouteUpdate?: NavigationGuard<V>;
   }
 }


### PR DESCRIPTION
Added support for resolving vm in the next((vm)=>{}) call.

```
@Component<Test>({
  beforeRouteEnter(to, from, next) {
    next((vm) => {
      vm.testBool = true;  //TypeScript resolved this field. 
    });
  },
})
export default class Test extends Vue {
  public testBool: boolean = false;
}
```
![image](https://user-images.githubusercontent.com/370042/45268762-6521ca80-b48a-11e8-988a-d4abcf4b4eef.png)
