### PR TITLE
Add Node.js(Express) Usage Example to Docs

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -70,6 +70,29 @@ http.createServer((req, res) => {
 
 For Node.js/Express, consider using [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback).
 
+##### Example
+```bash
+mkdir express_project
+cd express_project
+npm init
+npm i express connect-history-api-fallback -s
+touch app.js
+```
+
+```js
+// express_project/app.js
+
+const express = require('express')
+const history = require('connect-history-api-fallback')
+const app = express()
+const server = app
+    .use(history())
+    .use(express.static('dist'))
+    .listen(80, () => {
+        console.log('Node.js is listening to PORT:' + server.address().port)
+    })
+```
+
 #### Internet Information Services (IIS)
 
 1. Install [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -72,15 +72,15 @@ For Node.js/Express, consider using [connect-history-api-fallback middleware](ht
 
 ##### Example
 ```bash
-mkdir express_project
-cd express_project
+mkdir express-project
+cd express-project
 npm init
-npm i express connect-history-api-fallback -s
+npm install express connect-history-api-fallback
 touch app.js
 ```
 
 ```js
-// express_project/app.js
+// express-project/app.js
 
 const express = require('express')
 const history = require('connect-history-api-fallback')

--- a/docs/ja/guide/essentials/history-mode.md
+++ b/docs/ja/guide/essentials/history-mode.md
@@ -72,15 +72,15 @@ Node.js/Express では [connect-history-api-fallback middleware](https://github.
 
 ##### 利用例
 ```bash
-mkdir express_project
-cd express_project
+mkdir express-project
+cd express-project
 npm init
-npm i express connect-history-api-fallback -s
+npm install express connect-history-api-fallback
 touch app.js
 ```
 
 ```js
-// express_project/app.js
+// express-project/app.js
 
 const express = require('express')
 const history = require('connect-history-api-fallback')

--- a/docs/ja/guide/essentials/history-mode.md
+++ b/docs/ja/guide/essentials/history-mode.md
@@ -70,6 +70,29 @@ http.createServer((req, res) => {
 
 Node.js/Express では [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback) の利用を検討してください。
 
+##### 利用例
+```bash
+mkdir express_project
+cd express_project
+npm init
+npm i express connect-history-api-fallback -s
+touch app.js
+```
+
+```js
+// express_project/app.js
+
+const express = require('express')
+const history = require('connect-history-api-fallback')
+const app = express()
+const server = app
+    .use(history())
+    .use(express.static('dist'))
+    .listen(80, () => {
+        console.log('Node.js is listening to PORT:' + server.address().port)
+    })
+```
+
 #### Internet Information Services (IIS)
 
 1. [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite) をインストール

--- a/docs/kr/guide/essentials/history-mode.md
+++ b/docs/kr/guide/essentials/history-mode.md
@@ -69,6 +69,29 @@ http.createServer((req, res) => {
 
 Node.js/Express의 경우 [connect-history-api-fallback 미들웨어](https://github.com/bripkens/connect-history-api-fallback)를 고려해보세요.
 
+##### 예
+```bash
+mkdir express_project
+cd express_project
+npm init
+npm i express connect-history-api-fallback -s
+touch app.js
+```
+
+```js
+// express_project/app.js
+
+const express = require('express')
+const history = require('connect-history-api-fallback')
+const app = express()
+const server = app
+    .use(history())
+    .use(express.static('dist'))
+    .listen(80, () => {
+        console.log('Node.js is listening to PORT:' + server.address().port)
+    })
+```
+
 #### Internet Information Services (IIS)
 
 ```

--- a/docs/kr/guide/essentials/history-mode.md
+++ b/docs/kr/guide/essentials/history-mode.md
@@ -71,15 +71,15 @@ Node.js/Express의 경우 [connect-history-api-fallback 미들웨어](https://gi
 
 ##### 예
 ```bash
-mkdir express_project
-cd express_project
+mkdir express-project
+cd express-project
 npm init
-npm i express connect-history-api-fallback -s
+npm install express connect-history-api-fallback
 touch app.js
 ```
 
 ```js
-// express_project/app.js
+// express-project/app.js
 
 const express = require('express')
 const history = require('connect-history-api-fallback')

--- a/docs/ru/guide/essentials/history-mode.md
+++ b/docs/ru/guide/essentials/history-mode.md
@@ -72,15 +72,15 @@ http.createServer((req, res) => {
 
 ##### пример
 ```bash
-mkdir express_project
-cd express_project
+mkdir express-project
+cd express-project
 npm init
-npm i express connect-history-api-fallback -s
+npm install express connect-history-api-fallback
 touch app.js
 ```
 
 ```js
-// express_project/app.js
+// express-project/app.js
 
 const express = require('express')
 const history = require('connect-history-api-fallback')

--- a/docs/ru/guide/essentials/history-mode.md
+++ b/docs/ru/guide/essentials/history-mode.md
@@ -70,6 +70,29 @@ http.createServer((req, res) => {
 
 При использовании Node.js/Express, мы рекомендуем пользоваться [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback).
 
+##### пример
+```bash
+mkdir express_project
+cd express_project
+npm init
+npm i express connect-history-api-fallback -s
+touch app.js
+```
+
+```js
+// express_project/app.js
+
+const express = require('express')
+const history = require('connect-history-api-fallback')
+const app = express()
+const server = app
+    .use(history())
+    .use(express.static('dist'))
+    .listen(80, () => {
+        console.log('Node.js is listening to PORT:' + server.address().port)
+    })
+```
+
 #### Internet Information Services (IIS)
 
 1. Установить [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs/zh/guide/essentials/history-mode.md
+++ b/docs/zh/guide/essentials/history-mode.md
@@ -72,15 +72,15 @@ http.createServer((req, res) => {
 
 ##### 例
 ```bash
-mkdir express_project
-cd express_project
+mkdir express-project
+cd express-project
 npm init
-npm i express connect-history-api-fallback -s
+npm install express connect-history-api-fallback
 touch app.js
 ```
 
 ```js
-// express_project/app.js
+// express-project/app.js
 
 const express = require('express')
 const history = require('connect-history-api-fallback')

--- a/docs/zh/guide/essentials/history-mode.md
+++ b/docs/zh/guide/essentials/history-mode.md
@@ -70,7 +70,7 @@ http.createServer((req, res) => {
 
 对于 Node.js/Express，请考虑使用 [connect-history-api-fallback 中间件](https://github.com/bripkens/connect-history-api-fallback)。
 
-##### 例
+##### 例子
 ```bash
 mkdir express-project
 cd express-project

--- a/docs/zh/guide/essentials/history-mode.md
+++ b/docs/zh/guide/essentials/history-mode.md
@@ -70,6 +70,29 @@ http.createServer((req, res) => {
 
 对于 Node.js/Express，请考虑使用 [connect-history-api-fallback 中间件](https://github.com/bripkens/connect-history-api-fallback)。
 
+##### 例
+```bash
+mkdir express_project
+cd express_project
+npm init
+npm i express connect-history-api-fallback -s
+touch app.js
+```
+
+```js
+// express_project/app.js
+
+const express = require('express')
+const history = require('connect-history-api-fallback')
+const app = express()
+const server = app
+    .use(history())
+    .use(express.static('dist'))
+    .listen(80, () => {
+        console.log('Node.js is listening to PORT:' + server.address().port)
+    })
+```
+
 #### Internet Information Services (IIS)
 
 1. 安装 [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)


### PR DESCRIPTION
I thought that I needed documentation on usage examples in Node.js (Express).
So I will suggest adding a usage example in Node.js (Express).