### PR TITLE
Forward args as props to custom child

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -9,6 +9,7 @@ const eventTypes: Array<Function> = [String, Array]
 
 export default {
   name: 'RouterLink',
+  inheritAttrs: false,
   props: {
     to: {
       type: toTypes,
@@ -95,6 +96,7 @@ export default {
       } else {
         // doesn't have <a> child, apply listener to self
         data.on = on
+        data.props = this.$attrs
       }
     }
 


### PR DESCRIPTION
When rendering a custom child ("tag" prop) forward unhandled args to the component, like a button or something complex.

I believe this will not break any existing functionality while giving some new capabilities.

Guess this will fix #1678 and can be related to #2029.