### PR TITLE
docs(vuepress): move fr gitbook doc to vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -24,6 +24,11 @@ module.exports = {
       lang: 'kr',
       title: 'Vue Router',
       description: 'Vue.js 공식 라우터'
+    },
+    '/fr/': {
+        lang: 'fr',
+        title: 'Vue Router',
+        description: 'Routeur officiel pour Vue.Js'
     }
   },
   serviceWorker: true,
@@ -281,7 +286,57 @@ module.exports = {
             ]
           }
         ]
-      }
+      },
+      '/fr/': {
+          label: 'Français',
+          selectText: 'Langues',
+          editLinkText: 'Editer cette page sur Github',
+          nav: [
+              {
+                  text: 'Guide',
+                  link: '/fr/guide/'
+              },
+              {
+                  text: 'API',
+                  link: '/fr/api/'
+              },
+              {
+                  text: 'Notes de version',
+                  link: 'https://github.com/vuejs/vue-router/releases'
+              }
+          ],
+          sidebar: [
+              '/fr/installation.md',
+              '/fr/',
+              {
+                  title: 'Essentiels',
+                  collapsable: false,
+                  children: [
+                      '/fr/guide/',
+                      '/fr/guide/essentials/dynamic-matching.md',
+                      '/fr/guide/essentials/nested-routes.md',
+                      '/fr/guide/essentials/navigation.md',
+                      '/fr/guide/essentials/named-routes.md',
+                      '/fr/guide/essentials/named-views.md',
+                      '/fr/guide/essentials/redirect-and-alias.md',
+                      '/fr/guide/essentials/passing-props.md',
+                      '/fr/guide/essentials/history-mode.md'
+                  ]
+              },
+              {
+                  title: 'Avancés',
+                  collapsable: false,
+                  children: [
+                      '/fr/guide/advanced/navigation-guards.md',
+                      '/fr/guide/advanced/meta.md',
+                      '/fr/guide/advanced/transitions.md',
+                      '/fr/guide/advanced/data-fetching.md',
+                      '/fr/guide/advanced/scroll-behavior.md',
+                      '/fr/guide/advanced/lazy-loading.md'
+                  ]
+              }
+          ]
+      },
     }
   }
 }

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,0 +1,20 @@
+# Introduction
+
+<Bit/>
+
+:::tip VERSION NOTE
+Pour les utilisateurs de TypeScript, `vue-router@3.0+` requière `vue@2.5+`, et vice versa.
+:::
+
+Vue Router est le router officiel pour [Vue.js](http://vuejs.org). Il s'intègre aisément avec Vue.js pour faire des applications mono page avec Vue.js. Fonctionnalités incluses:
+
+- Vues et routes imbriquées
+- Modulaire, configuration basée sur les composants
+- Paramètres de route, de requête
+- Effets de transition de vues basées sur le systeme de transition de Vue.js
+- Gestion fine de la navigation
+- Classes CSS pour liens actifs
+- Mode HTML5 de la gestion de l'historique ou mode par hash, avec solution de repli automatique pour IE9
+- Gestion du scroll
+
+[Pour commencer](./guide/) ou jouer avec les [exemples](https://github.com/vuejs/vue-router/tree/dev/examples) (voir [`README.md`](https://github.com/vuejs/vue-router/) pour les faire fonctionner).

--- a/docs/fr/api/README.md
+++ b/docs/fr/api/README.md
@@ -1,0 +1,449 @@
+---
+sidebar: auto
+---
+
+# API
+
+<Bit/>
+
+## `<router-link>`
+
+`<router-link>` est le composant pour activer la navigation utilisateur dans une application où le routeur est activé. La localisation cible est spécifiée grâce à la prop `to`. Il est rendu en tant que balise `<a>` avec le `href` correct par défaut, mais peut être configuré grâce à la prop `tag`. De plus, le lien se verra attribuer une classe CSS active lorsque la route cible est active.
+
+`<router-link>` est préféré par rapport au `<a href="...">` en dur dans le code pour les raisons suivantes :
+
+- Cela fonctionne de la même manière qu'on soit dans le mode historique HTML5 ou le mode hash, donc si vous avez décidé de changer de mode, ou alors que le routeur se replie sur le mode hash pour IE9, rien n'a besoin d'être changé.
+
+- Dans le mode historique HTML5, `router-link` interceptera l'évènement du clic, comme ça le navigateur n'essaiera pas de rafraichir la page.
+
+- En utilisant l'option `base` dans le mode historique HTML5, vous n'avez pas besoin
+
+### Appliquer la classe active à l'élément extérieur
+
+Parfois, on voudrait que la classe active soit appliquée à un élément extérieur au lieu de l'élément `<a>` lui-même, dans ce cas, vous pouvez faire le rendu de cet élément extérieur en utilisant `<router-link>` et en entourant le tag `<a>` :
+
+``` html
+<router-link tag="li" to="/foo">
+  <a>/foo</a>
+</router-link>
+```
+
+Dans ce cas, `<a>` sera le lien actuel (et récupèrera le bon `href`), mais la classe active sera appliquée à l'élément extérieur `<li>`.
+
+## `<router-link>` Props
+
+### to
+
+- type : `string | Location`
+- requis
+
+   Désigne la route cible du lien. Lorsqu'il est cliqué, la valeur de la prop `to` va être passée de manière interne à `router.push`, donc la valeur peut soit être une chaine de caractères, ou alors un objet décrivant une localisation.
+
+  ``` html
+  <!--  chaine littérale  -->
+  <router-link to="home">Accueil</router-link>
+  <!-- rend -->
+  <a href="home">Accueil</a>
+
+  <!-- expression JavaScript en utilisant `v-bind` -->
+  <router-link v-bind:to="'home'">Accueil</router-link>
+
+  <!-- Omettre `v-bind` est OK, tout comme une autre prop -->
+  <router-link :to="'home'">Accueil</router-link>
+
+  <!-- pareil qu'au-dessus -->
+  <router-link :to="{ path: 'home' }">Accueil</router-link>
+
+  <!-- route nommée -->
+  <router-link :to="{ name: 'user', params: { userId: 123 }}">Utilisateur</router-link>
+
+  <!-- avec une requête, résulte en `/register?plan=private` -->
+  <router-link :to="{ path: 'register', query: { plan: 'private' }}">S'enregistrer</router-link>
+  ```
+
+
+### replace
+
+- type : `boolean`
+- défaut : `false`
+
+  Configurer la prop `replace` appellera `router.replace()` au lieu de `router.push()` lors du clic, comme ça, la navigation ne laissera pas un enregistrement dans l'historique.
+
+  ``` html
+  <router-link :to="{ path: '/abc'}" replace></router-link>
+  ```
+
+
+### append
+
+- type : `boolean`
+- défaut : `false`
+
+  Configurer la propriété `append` suffixe toujours le chemin relatif au chemin courant. Par exemple, assumons que nous naviguons de `/a` à un lien relatif `b`, sans `append` on finira sur `/b`, mais avec `append` on finira sur `/a/b`.
+
+  ``` html
+  <router-link :to="{ path: 'relative/path'}" append></router-link>
+  ```
+
+
+### tag
+
+- type : `string`
+- défaut : `"a"`
+
+  Parfois, on veut que `<router-link>` soit rendu avec une balise différente, ex : `<li>`. On peut alors utiliser la prop `tag` pour modifier la balise qui sera rendue, et elle écoutera toujours les évènements de clic pour la navigation.
+
+  ``` html
+  <router-link to="/foo" tag="li">foo</router-link>
+  <!-- rend -->
+  <li>foo</li>
+  ```
+
+
+### active-class
+
+- type : `string`
+- défaut : `"router-link-active"`
+
+  Configure la classe CSS active qui sera appliquée lorsque le lien sera actif. Notez que la valeur par défaut peut aussi être configurée de manière globale via l'option `linkActiveClass` du constructeur du routeur.
+
+### exact
+
+  - type : `boolean`
+
+  - défaut : `false`
+
+  Le comportement par défaut de la correspondance de classe active est une **correspondance inclusive**. Par exemple, `<router-link to="/a">` verra cette classe appliquée tant que le chemin courant commencera par `/a/` ou `/a`.
+
+  Une conséquence de cela est que `<router-link to="/">` sera actif pour toutes les routes ! Pour forcer le lien dans un « mode correspondance exacte », utilisez la prop `exact`.
+
+  ``` html
+  <!-- ce lien sera uniquement actif à `/` -->
+  <router-link to="/" exact>
+  ```
+
+  Allez voir les exemples expliquant la classe active pour les liens [ici](https://jsfiddle.net/8xrk1n9f/).
+
+### event
+
+- type : `string | Array<string>`
+- défaut : `'click'`
+
+  Spécifie les évènement(s) que peu(ven)t lancer la navigation de lien.
+
+### exact-active-class**
+
+- type : `string`
+- défaut : `"router-link-exact-active"`
+
+  Configure la classe CSS active qui sera appliquée lorsqu'un lien sera actif avec une correspondance exacte. Notez que la valeur par défaut peut aussi être configurée de manière globale via l'option `linkExactActiveClass` du constructeur du routeur.
+
+## `<router-view>`
+
+Le composant `<router-view>` est un composant fonctionnel qui fait le rendu du composant correspondant au chemin donné. Les composants rendus dans `<router-view>` peuvent aussi contenir leur propre `<router-view>`, qui fera le rendu des composants pour les chemins imbriqués.
+
+## `<router-view>` Props
+
+### name
+
+- type : `string`
+- défaut : `"default"`
+
+  Lorsqu'un `<router-view>` a un nom, il fera le rendu du composant correspondant à ce nom dans les itinéraires de route correspondant à l'option `components`. Voir les [Routes nommées](../essentials/named-views.md) pour un exemple.
+
+## Options de construction du routeur
+
+### routes
+
+- type: `Array<RouteConfig>`
+
+  Déclaration de type pour `RouteConfig` :
+
+  ``` js
+  declare type RouteConfig = {
+    path: string;
+    component?: Component;
+    name?: string; // pour les routes nommées
+    components?: { [name: string]: Component }; // pour les vues nommées
+    redirect?: string | Location | Function;
+    props?: boolean | string | Function;
+    alias?: string | Array<string>;
+    children?: Array<RouteConfig>; // pour les routes imbriquées
+    beforeEnter?: (to: Route, from: Route, next: Function) => void;
+    meta?: any;
+
+    // 2.6.0+
+    caseSensitive?: boolean; // use case sensitive match? (default: false)
+    pathToRegexpOptions?: Object; // path-to-regexp options for compiling regex
+  }
+  ```
+
+### mode
+
+- type : `string`
+
+- défaut : `"hash" (dans le navigateur) | "abstract" (en Node.js)`
+
+- valeurs disponibles : `"hash" | "history" | "abstract"`
+
+  Configure le mode du routeur.
+
+  - `hash` : utilise le hash de l'URL pour le routage. Fonctionne dans tous les navigateurs supportés par Vue, ainsi que ceux qui ne supportent pas l'API History d'HTML5.
+
+  - `history` : nécessite l'API History d'HTML 5 et la configuration du serveur. Voir [Mode historique de HTML5](../essentials/history-mode.md).
+
+  - `abstract` : fonctionne dans tous les environnements JavaScript, ex. côté serveur avec Node.js. **Le routeur sera automatiquement forcé d'utiliser ce mode si aucune API navigateur n'est présente.**
+
+### base
+
+- type : `string`
+
+- défaut : `"/"`
+
+  L'URL de base de l'application. Par exemple, si l'application monopage entière est distribuée sous `/app/`, alors `base` doit utiliser la valeur `"/app/"`.
+
+### linkActiveClass
+
+- type : `string`
+
+- défaut : `"router-link-active"`
+
+  Configure de manière globale la classe active par défaut de `<router-link>`. Voir aussi [router-link](router-link.md).
+
+### linkExactActiveClass
+
+- type : `string`
+
+- default : `"router-link-exact-active"`
+
+  Configure de manière globale la classe active par défaut de `<router-link>` lors d'une correspondance exacte. Voir aussi [router-link](router-link.md).
+
+### scrollBehavior
+
+- type : `Function`
+
+  Signature :
+
+  ```
+  type PositionDescriptor =
+    { x: number, y: number } |
+    { selector: string } |
+    ?{}
+
+  type scrollBehaviorHandler = (
+    to: Route,
+    from: Route,
+    savedPosition?: { x: number, y: number }
+  ) => PositionDescriptor | Promise<PositionDescriptor>
+  ```
+
+  Pour plus de détails, voir [Comportement du Scroll](../advanced/scroll-behavior.md).
+
+### parseQuery / stringifyQuery
+
+- type : `Function`
+
+  Permettent de spécifier des fonctions personnalisées pour formater en objet ou en chaîne de caractères la requête. Surcharge les fonctions par défaut.
+
+### fallback
+
+- type : `boolean`
+
+  Contrôle comment le routeur devrait passer en mode `hash` quand le navigateur ne supporte pas `history.pushState`. Par défaut à `true`.
+
+  Passer cette valeur à `false` va essentiellement faire que la navigation via `router-link` va réclamer un rechargement de page dans IE9. Ceci est utile quand l'application est rendue côté serveur et à besoin de fonctionner dans IE9, car le mode hash ne fonctionne pas avec du SSR.
+
+## L'instance du routeur
+
+### router.app
+
+- type: `instance de Vue`
+
+ L'instance racine de Vue dans laquelle l'instance de `routeur` a été injectée.
+
+### router.mode
+
+- type: `string`
+
+  Le [mode](options.md#mode) que le routeur utilise.
+
+### router.currentRoute
+
+- type: `Route`
+
+  La route actuelle représentée en tant qu'un [objet route](route-object.md).
+
+## Méthodes
+
+### router.beforeEach
+### router.beforeResolve
+### router.afterEach
+
+  Ajout des interceptions globales de navigation. Voir les [Intercepteurs de navigation](../advanced/navigation-guards.md).
+
+  Dans la version 2.5.0+, ces trois méthodes retournent une fonction qui enlève les fonctions d'interception et hooks enregistrés.
+
+### router.push
+### router.replace
+### router.go
+### router.back
+### router.forward
+
+  Navigue à une nouvelle URL de façon programmée. Voir [Navigation de façon programmée](../essentials/navigation.md).
+
+### router.getMatchedComponents
+
+  Retourne un tableau de composants (définition/constructeur et non les instances) correspondant à la `location` passée en paramètre, ou alors de la route actuelle. Cette fonction est principalement utilisée pendant le rendu côté serveur afin d'effectuer une prérécupération des données.
+
+### router.resolve
+
+  Inverse la résolution d'URL. La `location` doit avoir la même forme qu'utilisée dans `<router-link>`, retourne un objet avec les propriétés suivantes :
+
+  ``` js
+  {
+    location: Location;
+    route: Route;
+    href: string;
+  }
+  ```
+
+  - `current` is the current Route by default (most of the time you don't need to change this)
+  - `append` allows you to append the path to the `current` route (as with [`router-link`](router-link.md#props))
+
+### router.addRoutes
+
+  Permet d'ajouter dynamiquement des routes au routeur. L'argument doit être un tableau utilisant le même format de configuration que l'option `routes` du constructeur.
+
+### router.onReady
+
+  Cette méthode met en file d'attente une fonction de rappel qui sera appelée lorsque le routeur aura complété la navigation initiale, ce qui signifie qu'il a résolu tous les hooks d'entrées asynchrones et composants asynchrones qui sont associés à la route initiale.
+
+  C'est utile pendant un rendu côté serveur pour assurer une sortie consistance sur le serveur et le client.
+
+  Le deuxième argument `errorCallback` est uniquement supporté à partir de la version 2.4. Il sera appelé lorsque la résolution de la route initiale résultera en une erreur (ex. : la résolution d'un composant asynchrone qui a échoué).
+
+### router.onError
+
+  Enregistre une fonction de rappel qui sera appelée lorsqu'une erreur sera capturée pendant la navigation vers une route. Notez que pour qu'une erreur soit appelée, cela doit correspondre à l'un des scénarios suivants :
+
+  - L'erreur est lancée de manière synchrone à l'intérieur d'une fonction d'interception de route ;
+
+  - L'erreur est capturée et traitée de manière asynchrone en appelant `next(err)` à l'intérieur d'une fonction d'interception de route ;
+
+  - Une erreur est survenue pendant la résolution d'un composant asynchrone qui est requis pour faire le rendu d'une route.
+
+# L'objet `Route`
+
+Un **objet `Route`** représente l'état actuel de la route active. Il contient des informations analysées à propos de l'URL courant et **les itinéraires de route** appariés par l'URL.
+
+L'objet `Route` est immutable. Chaque navigation qui se déroule avec succès résultera en un nouvel objet `Route`.
+
+L'objet `Route` peut être trouvé à plusieurs endroits :
+
+- À l'intérieur des composants en tant que `this.$route`
+
+- À l'intérieur des fonctions de rappel des observateurs de `$route`
+
+- Comme valeur de retour après l'appel de `router.match(location)`
+
+- À l'intérieur des fonctions d'interception de la navigation, dans les deux premiers paramètres de la fonction :
+
+  ``` js
+  router.beforeEach((to, from, next) => {
+    // `to` et `from` sont tous les deux des objets Route
+  })
+  ```
+
+- À l'intérieur de la fonction `scrollBehavior` dans les deux premiers arguments :
+
+  ``` js
+  const router = new VueRouter({
+    scrollBehavior (to, from, savedPosition) {
+      // `to` et `from` sont tous les deux des objets Route
+    }
+  })
+  ```
+
+### Propriétés de l'objet `Route`
+
+- **$route.path**
+
+  - type : `string`
+
+    Une chaine de caractères représentant le chemin de la route en cours, toujours résolue en tant que chemin absolu, ex : `"/foo/bar"`.
+
+- **$route.params**
+
+  - type : `Object`
+
+    Un objet qui contient des pairs clé/valeur de segments dynamiques et segments *star*. S'il n'y a pas de paramètres, alors la valeur sera un objet vide.
+
+- **$route.query**
+
+  - type : `Object`
+
+    Un objet qui contient des pairs clé/valeur de la requête au format d'une chaine de caractères. Par exemple, pour un chemin `/foo?user=1`, on aura `$route.query.user == 1`. S'il n'y a pas de requête, alors la valeur sera un objet vide.
+
+- **$route.hash**
+
+  - type : `string`
+
+    Le hash de la route courante (avec le `#`), s'il y en a un. S'il n'y a pas de hash, alors la valeur sera une chaine de caractères vide.
+
+- **$route.fullPath**
+
+  - type : `string`
+
+    L'URL entièrement résolu, incluant la requête et le hash.
+
+- **$route.matched**
+
+  - type : `Array<RouteRecord>`
+
+    Un `Array` contenant les **les itinéraires de la route** pour chaque segment de chemin imbriqué de la route courante. Les itinéraires de la route sont des copies des objets dans le tableau de configuration `routes` (et dans les tableaux `children`).
+
+  ``` js
+  const router = new VueRouter({
+    routes: [
+      // l'objet qui suit est un itinéraire de route
+      { path: '/foo', component: Foo,
+        children: [
+          // c'est aussi un itinéraire
+          { path: 'bar', component: Bar }
+        ]
+      }
+    ]
+  })
+  ```
+
+  Lorsque l'URL sera `/foo/bar`, `$route.matched` sera un `Array` contenant les deux objets (clonés), dans l'ordre parent à l'enfant.
+
+- **$route.name**
+
+  Le nom de la route courante, si elle en a un. (Voir [Routes nommées](../essentials/named-routes.md)).
+
+- **$route.redirectedFrom**
+
+  Le nom de la route d'où la page a été redirigée, si elle en a un. (Voir [Redirection et alias](../essentials/redirect-and-alias.md)).
+
+## Injections de composant
+
+### Propriétés injectées
+
+Ces propriétés sont injectées dans chacun des composants enfants, en passant l'instance du routeur à l'application racine de Vue en tant qu'option `router`.
+
+- **$router**
+
+  L'instance du routeur.
+
+- **$route**
+
+ La [Route](route-object.md) actuellement active. C'est une propriété en lecture seule et ses propriétés sont immutables, mais elles restent malgré tout observables.
+
+### Options activées
+
+- **beforeRouteEnter**
+- **beforeRouteUpdate** (ajouté en 2.2)
+- **beforeRouteLeave**
+
+  Voir l'[interception par composant](../advanced/navigation-guards.md#securisation-par-composant).

--- a/docs/fr/guide/README.md
+++ b/docs/fr/guide/README.md
@@ -1,10 +1,13 @@
 # Pour commencer
 
-> Nous utiliserons [ES2015](https://github.com/lukehoban/es6features) dans les exemples de code dans ce guide.
+<Bit/>
+
+::: tip Note
+Nous utiliserons [ES2015](https://github.com/lukehoban/es6features) dans les exemples de code dans ce guide.
+ Tous les exemples utiliseront la version complète de Vue pour rendre l'analyse de template possible. Plus de détails [ici](https://fr.vuejs.org/guide/installation.html#Runtime-Compiler-vs-Runtime-seul).
+:::
 
 Créer une application monopage avec Vue + Vue Router est vraiment simple. Avec Vue.js, nous concevons déjà notre application avec des composants. En ajoutant vue-router dans notre application, tout ce qu'il nous reste à faire est de relier nos composants aux routes, et de laisser vue-router faire le rendu. Voici un exemple de base :
-
-> Tous les exemples utiliseront la version complète de Vue pour rendre l'analyse de template possible. Plus de détails [ici](https://fr.vuejs.org/guide/installation.html#Runtime-Compiler-vs-Runtime-seul).
 
 ## HTML
 
@@ -89,4 +92,4 @@ Dans les documentations, nous allons souvent utiliser l'instance `router`. Garde
 
 Vous pouvez aussi regarder cet [exemple](https://jsfiddle.net/yyx990803/xgrjzsup/).
 
-Notez qu'un `<router-link>` obtiendra automatiquement la classe `.router-link-active` lorsque sa route cible correspond à la route actuelle. Vous pouvez en apprendre plus à propos de cela dans sa [documentation d'API](../api/router-link.md).
+Notez qu'un `<router-link>` obtiendra automatiquement la classe `.router-link-active` lorsque sa route cible correspond à la route actuelle. Vous pouvez en apprendre plus à propos de cela dans sa [documentation d'API](../api/#router-link).

--- a/docs/fr/guide/README.md
+++ b/docs/fr/guide/README.md
@@ -1,0 +1,92 @@
+# Pour commencer
+
+> Nous utiliserons [ES2015](https://github.com/lukehoban/es6features) dans les exemples de code dans ce guide.
+
+Créer une application monopage avec Vue + Vue Router est vraiment simple. Avec Vue.js, nous concevons déjà notre application avec des composants. En ajoutant vue-router dans notre application, tout ce qu'il nous reste à faire est de relier nos composants aux routes, et de laisser vue-router faire le rendu. Voici un exemple de base :
+
+> Tous les exemples utiliseront la version complète de Vue pour rendre l'analyse de template possible. Plus de détails [ici](https://fr.vuejs.org/guide/installation.html#Runtime-Compiler-vs-Runtime-seul).
+
+## HTML
+
+``` html
+<script src="https://unpkg.com/vue/dist/vue.js"></script>
+<script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
+
+<div id="app">
+  <h1>Bonjour l'application !</h1>
+  <p>
+    <!-- utilisez le composant router-link pour la navigation. -->
+    <!-- spécifiez le lien en le passant à la prop `to` -->
+    <!-- `<router-link>` sera rendu en tag `<a>` par défaut -->
+    <router-link to="/foo">Aller à Foo</router-link>
+    <router-link to="/bar">Aller à Bar</router-link>
+  </p>
+  <!-- balise pour le composant router-view -->
+  <!-- le composant correspondant à la route sera rendu ici -->
+  <router-view></router-view>
+</div>
+```
+
+## JavaScript
+
+``` js
+// 0. Si vous utilisez un système de module (par ex. via vue-cli), il faut importer Vue et Vue Router et ensuite appeler `Vue.use(VueRouter)`.
+
+// 1. Définissez les composants de route.
+// Ces derniers peuvent être importés depuis d'autre fichier
+const Foo = { template: '<div>foo</div>' }
+const Bar = { template: '<div>bar</div>' }
+
+// 2. Définissez des routes.
+// Chaque route doit correspondre à un composant. Le « composant » peut
+// soit être un véritable composant créé via `Vue.extend()`, ou juste un
+// objet d'options.
+// Nous parlerons plus tard des routes imbriquées.
+const routes = [
+  { path: '/foo', component: Foo },
+  { path: '/bar', component: Bar }
+]
+
+// 3. Créez l'instance du routeur et passez l'option `routes`.
+// Vous pouvez également passer des options supplémentaires,
+// mais nous allons faire simple pour l'instant.
+const router = new VueRouter({
+  routes // raccourci pour `routes: routes`
+})
+
+// 5. Créez et montez l'instance de Vue.
+// Soyez sûr d'injecter le routeur avec l'option `router` pour
+// permettre à l'application tout entière d'être à l'écoute du routeur.
+const app = new Vue({
+  router
+}).$mount('#app')
+
+// L'application est maintenant en marche !
+```
+
+En injectant le routeur, nous y avons accès à travers `this.$router`. Nous avons également accès à la route courante derrière `this.$route` depuis n'importe quel composant :
+
+```js
+// Home.vue
+export default {
+  computed: {
+    username () {
+      // Nous verrons ce que représente `params` dans un instant.
+      return this.$route.params.username
+    }
+  },
+  methods: {
+    goBack () {
+      window.history.length > 1
+        ? this.$router.go(-1)
+        : this.$router.push('/')
+    }
+  }
+}
+```
+
+Dans les documentations, nous allons souvent utiliser l'instance `router`. Gardez à l'esprit que l'utilisation de `this.$router` est exactement la même chose que celle de `router`. La raison pour laquelle nous utilisons `this.$router` est la possibilité ainsi offerte de ne pas avoir à importer le routeur dans chaque fichier de composant ayant besoin d'accéder au routage.
+
+Vous pouvez aussi regarder cet [exemple](https://jsfiddle.net/yyx990803/xgrjzsup/).
+
+Notez qu'un `<router-link>` obtiendra automatiquement la classe `.router-link-active` lorsque sa route cible correspond à la route actuelle. Vous pouvez en apprendre plus à propos de cela dans sa [documentation d'API](../api/router-link.md).

--- a/docs/fr/guide/advanced/data-fetching.md
+++ b/docs/fr/guide/advanced/data-fetching.md
@@ -1,0 +1,110 @@
+# Récupération de données
+
+Parfois vous avez besoin de récupérer des données depuis le serveur lorsqu'une route est activée. Par exemple, avant de faire le rendu d'un profil utilisateur, vous avez besoin de récupérer les données de l'utilisateur depuis le serveur. Nous pouvons y parvenir de deux façons différentes :
+
+- **Récupération de données après la navigation** : effectue la navigation en premier, et récupère les données dans le hook entrant du cycle de vie d'un composant. Affiche un état de chargement pendant que les données sont en train d'être récupérées.
+
+- **Récupération de données avant la navigation** : récupère les données avant la navigation dans la fonction d'interception d'entrée de la route, et effectue la navigation après que les données aient été récupérées.
+
+Techniquement, les deux choix sont valides. Cela dépend de l'expérience utilisateur que vous souhaitez apporter.
+
+## Récupération de données après la navigation
+
+En utilisant cette approche, nous naviguons et faisons immédiatement le rendu du composant et récupérons les données via le hook `created` du composant. Cela nous donne l'opportunité d'afficher un état de chargement pendant que les données sont récupérées à travers le réseau, et nous pouvons aussi gérer le chargement différemment pour chaque vue.
+
+Assumons que nous ayons un composant `Post` qui a besoin de récupérer des données pour un billet identifié par `$route.params.id` :
+
+``` html
+<template>
+  <div class="post">
+    <div class="loading" v-if="loading">
+      Chargement...
+    </div>
+
+    <div v-if="error" class="error">
+      {{ error }}
+    </div>
+
+    <div v-if="post" class="content">
+      <h2>{{ post.title }}</h2>
+      <p>{{ post.body }}</p>
+    </div>
+  </div>
+</template>
+```
+
+``` js
+export default {
+  data () {
+    return {
+      loading: false,
+      post: null,
+      error: null
+    }
+  },
+  created () {
+    // récupérer les données lorsque la vue est créée et
+    // que les données sont déjà observées
+    this.fetchData()
+  },
+  watch: {
+    // appeler encore la méthode si la route change
+    '$route': 'fetchData'
+  },
+  methods: {
+    fetchData () {
+      this.error = this.post = null
+      this.loading = true
+      // remplacer `getPost` par une fonction de récupération de données
+      getPost(this.$route.params.id, (err, post) => {
+        this.loading = false
+        if (err) {
+          this.error = err.toString()
+        } else {
+          this.post = post
+        }
+      })
+    }
+  }
+}
+```
+
+## Récupération de données avant la navigation
+
+Avec cette approche, nous récupèrerons les données avant de naviguer vers la nouvelle route. Nous pouvons effectuer la récupération de données dans la fonction d'interception `beforeRouteEnter` du composant à venir, et seulement appeler `next` lorsque la récupération est terminée :
+
+``` js
+export default {
+  data () {
+    return {
+      post: null,
+      error: null
+    }
+  },
+  beforeRouteEnter (to, from, next) {
+    getPost(to.params.id, (err, post) => {
+      next(vm => vm.setData(err, post))
+    })
+  },
+  // quand la route change et que ce composant est déjà rendu,
+  // la logique est un peu différente
+  beforeRouteUpdate (to, from, next) {
+    this.post = null
+    getPost(to.params.id, (err, post) => {
+      this.setData(err, post)
+      next()
+    })
+  },
+  methods: {
+    setData (err, post) {
+      if (err) {
+        this.error = err.toString()
+      } else {
+        this.post = post
+      }
+    }
+  }
+}
+```
+
+L'utilisateur va rester sur la vue précédente pendant que la ressource est en train d'être récupérée pour la vue à venir. Il est cependant recommandé d'afficher une barre de progression ou un autre type d'indicateur pendant que les données sont en train d'être récupérées. Si la récupération échoue, il est aussi recommandé d'afficher une sorte de message d'erreur global.

--- a/docs/fr/guide/advanced/lazy-loading.md
+++ b/docs/fr/guide/advanced/lazy-loading.md
@@ -1,0 +1,47 @@
+# Chargement à la volée
+
+Pendant la construction d'applications avec un empaqueteur (« bundler »), le paquetage JavaScript peut devenir un peu lourd, et donc cela peut affecter le temps de chargement de la page. Il serait plus efficace si l'on pouvait séparer chaque composant de route dans des fragments séparés, et de les charger uniquement lorsque la route est visitée.
+
+En combinant la [fonctionnalité de composant asynchrone](https://fr.vuejs.org/v2/guide/components.html#Composants-asynchrones) de Vue et la [fonctionnalité de scission de code](https://webpack.js.org/guides/code-splitting-async/) de webpack, il est très facile de charger à la volée les composants de route.
+
+Premièrement, un composant asynchrone peut définir une fonction fabrique qui retourne une Promesse (qui devrait résoudre le composant lui-même) :
+
+``` js
+const Foo = () => Promise.resolve({ /* définition du composant */ })
+```
+
+Deuxièmement, avec webpack 2, nous pouvons utiliser la syntaxe d'[import dynamique](https://github.com/tc39/proposal-dynamic-import) pour indiquer un point de scission de code :
+
+``` js
+import('./Foo.vue') // returns a Promise
+```
+
+> Note: si vous utilisez Babel, vous aurez besoin d'ajouter le plugin [syntax-dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) de façon à ce que Babel puisse analyser correctement la syntaxe.
+
+En combinant les deux, on définit un composant asynchrone qui sera automatiquement scindé par webpack :
+
+``` js
+const Foo = () => import('./Foo.vue')
+```
+
+Rien n'a besoin d'être modifié dans la configuration de la route, utilisez `Foo` comme d'habitude.
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/foo', component: Foo }
+  ]
+})
+```
+
+## Grouper des composants dans le même fragment
+
+Parfois on aimerait grouper tous les composants imbriqués sous la même route, dans un seul et même fragment asynchrone. Pour arriver à cela, nous avons besoin d'utiliser les [fragments nommés](https://webpack.js.org/guides/code-splitting-async/#chunk-names) en donnant un nom au fragment en utilisant une syntaxe de commentaire spéciale (requires webpack > 2.4) :
+
+``` js
+const Foo = () => import(/* webpackChunkName: "group-foo" */ './Foo.vue')
+const Bar = () => import(/* webpackChunkName: "group-foo" */ './Bar.vue')
+const Baz = () => import(/* webpackChunkName: "group-foo" */ './Baz.vue')
+```
+
+webpack groupera tous les modules asynchrones avec le même nom de fragment dans le même fragment asynchrone.

--- a/docs/fr/guide/advanced/lazy-loading.md
+++ b/docs/fr/guide/advanced/lazy-loading.md
@@ -16,7 +16,9 @@ Deuxièmement, avec webpack 2, nous pouvons utiliser la syntaxe d'[import dynami
 import('./Foo.vue') // returns a Promise
 ```
 
-> Note: si vous utilisez Babel, vous aurez besoin d'ajouter le plugin [syntax-dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) de façon à ce que Babel puisse analyser correctement la syntaxe.
+::: tip Note
+si vous utilisez Babel, vous aurez besoin d'ajouter le plugin [syntax-dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) de façon à ce que Babel puisse analyser correctement la syntaxe.
+:::
 
 En combinant les deux, on définit un composant asynchrone qui sera automatiquement scindé par webpack :
 

--- a/docs/fr/guide/advanced/meta.md
+++ b/docs/fr/guide/advanced/meta.md
@@ -1,0 +1,51 @@
+# Champs meta de route
+
+Vous pouvez inclure un champ `meta` quand vous définissez une route :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/foo',
+      component: Foo,
+      children: [
+        {
+          path: 'bar',
+          component: Bar,
+          // un champ `meta`
+          meta: { requiresAuth: true }
+        }
+      ]
+    }
+  ]
+})
+```
+
+Comment maintenant accéder à ce champ `meta` ?
+
+Tout d'abord, chaque objet route dans la configuration de `routes` est appelé un **registre de route**. Les registres de route peuvent être imbriqués. Par conséquent, quand une route concorde, elle peut potentiellement concorder avec plus d'un registre de route.
+
+Par exemple, avec la configuration de route ci-dessous, l'URL `/foo/bar` va concorder avec le registre parent et le registre enfant.
+
+Tous les registres concordants avec une route sont exposés dans l'objet `$route` (ainsi que les objets de route dans les sécurisations de navigation) dans le tableau `$route.matched`. Donc, nous devons itérer à travers `$route.matched` pour vérifier les champs meta dans les registres de route.
+
+Un exemple concret est la vérification d'un champ meta dans une interception de navigation globale :
+
+``` js
+router.beforeEach((to, from, next) => {
+  if (to.matched.some(record => record.meta.requiresAuth)) {
+    // cette route demande une autorisation, vérifions si l'utilisateur est logué.
+    // sinon, redirigeons le sur la page de login.
+    if (!auth.loggedIn()) {
+      next({
+        path: '/login',
+        query: { redirect: to.fullPath }
+      })
+    } else {
+      next()
+    }
+  } else {
+    next() // assurez vous de toujours appeler `next()` !
+  }
+})
+```

--- a/docs/fr/guide/advanced/navigation-guards.md
+++ b/docs/fr/guide/advanced/navigation-guards.md
@@ -1,0 +1,155 @@
+# Intercepteurs de navigation
+
+Comme le nom le suggère, l'interception de navigation fournie par `vue-router` est principalement utilisée pour intercepter la navigation avec des redirections ou des annulations d'accès. Il y a plusieurs hooks disponibles lors du processus de navigation : globaux, par route ou par composant.
+
+Souvenez-vous de cela : **le changement de paramètre ou de query ne va pas lancer d'interception d'entrée ou de sortie de navigation**. Vous pouvez toujours [observer l'objet `$route`](../essentials/dynamic-matching.md#reacting-to-params-changes) pour réagir à ces changements, ou utiliser la fonction `beforeRouteUpdate` d'une interception par composant.
+
+## Interception globale
+
+Vous pouvez abonner une interception d'entrée en utilisant `router.beforeEach` :
+
+``` js
+const router = new VueRouter({ ... })
+
+router.beforeEach((to, from, next) => {
+  // ...
+})
+```
+
+Les interceptions d'entrées globales sont appelées lors de l'ordre de création, chaque fois qu'une navigation est déclenchée. Les interceptions peuvent être résolues de manière asynchrone, et la navigation est considérée comme **en attente** avant que tous les hooks ne soient résolus.
+
+Chaque fonction d'interception reçoit trois arguments :
+
+- **`to: Route`**: L'[objet `Route`](../../api/#options-de-construction-du-routeur) cible vers lequel on navigue.
+
+- **`from: Route`**: la route courante depuis laquelle nous venons de naviguer.
+
+- **`next: Function`**: cette fonction doit être appelée pour **résoudre** le hook. L'action dépend des arguments fournis à `next`:
+
+  - **`next()`**: se déplacer jusqu'au prochain hook du workflow. S'il ne reste aucun hook, la navigation est **confirmée**.
+
+  - **`next(false)`**: annuler la navigation courante. Si l'URL du navigateur avait changé (manuellement par l'utilisateur ou via le bouton retour du navigateur), il sera remis à sa valeur de route de `from`.
+
+  - **`next('/')` ou `next({ path: '/' })`**: redirige vers le nouvel URL. La navigation courante va être arrêtée et une nouvelle va se lancer. Vous pouvez passer n'importe quel objet à `next`, vous permettant ainsi de spécifier des options comme `replace: true`, `name: 'home'` et n'importe quelles options dans [la prop `to` du `router-link`](../../api/#router-link) ou [`router.push`](../../api/#l-instance-du-routeur).
+
+  - **`next(error)`**: (2.4.0+) si l'argument passé à `next` est une instance de `Error`, la navigation va s'arrêter et l'erreur sera passée aux fonctions de rappel enregistrées via [`router.onError()`](../../api/#l-instance-du-routeur).
+
+**Assurez-vous de toujours appeler la fonction `next`, sinon le hook ne sera jamais résolu.**
+
+## Résolutions des interceptions globales
+
+> Nouveau dans la 2.5.0
+
+Dans la 2.5.0+ vous pouvez abonner une interception globale avec `router.beforeResolve`. Ceci est similaire a `router.beforeEach`, mais la différence est qu'elle sera appelée juste après que la navigation soit confirmée, **après que toutes les interceptions par composants et les composants de route asynchrone ait été résolu**.
+
+## Hooks de sortie globaux
+
+Vous pouvez également abonner des hooks de sortie, cependant, à la différence des interceptions, ces hooks ne fournissent pas de fonction `next` et n'affecte pas la navigation :
+
+``` js
+router.afterEach((to, from) => {
+  // ...
+})
+```
+
+## Interception par route
+
+Vous pouvez définir l'interception `beforeEnter` directement sur l'objet de configuration d'une route :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/foo',
+      component: Foo,
+      beforeEnter: (to, from, next) => {
+        // ...
+      }
+    }
+  ]
+})
+```
+
+Ces interceptions ont exactement le même effet que les interceptions globales d'entrée.
+
+## Interception par composant
+
+Enfin, vous pouvez directement définir une interception de navigation a l'intérieur du composant lui-même (celui passer à la configuration du routeur) avec les options suivantes :
+
+- `beforeRouteEnter`
+- `beforeRouteUpdate` (ajouté dans la 2.2+)
+- `beforeRouteLeave`
+
+``` js
+const Foo = {
+  template: `...`,
+  beforeRouteEnter (to, from, next) {
+    // appelée avant que la route vers le composant soit confirmée.
+    // cette fonction n'a pas accès à l'instance du composant avec `this`,
+    // car le composant n'a pas encore été créé quand cette interception est appelée !
+  },
+  beforeRouteUpdate (to, from, next) {
+    // appelée quand la route qui fait le rendu de ce composant change,
+    // mais que ce composant est utilisé de nouveau dans la nouvelle route.
+    // Par exemple, pour une route avec le paramètre dynamique `/foo/:id`, quand nous
+    // naviguons entre `/foo/1` et `/foo/2`, la même instance du composant `Foo`
+    // va être réutilisée, et ce hook va être appelé quand cela arrivera.
+    // ce hook a accès à l'instance de ce composant via `this`.
+  },
+  beforeRouteLeave (to, from, next) {
+    // appelée quand la route qui fait le rendu de ce composant est sur le point
+    // d'être laissée en faveur de la prochaine route.
+    // elle a accès à l'instance de ce composant via `this`.
+  }
+}
+```
+
+L'interception `beforeRouteEnter` **n'**a **PAS** accès à `this`, car l'interception est appelée avant que la navigation soit confirmée, et le nouveau composant entrant n'a même pas encore été créé.
+
+Cependant, vous pouvez accéder à l'instance en passant dans la fonction de rappel `next`. Cette fonction de rappel va être appelée quand la navigation sera confirmée, et l'instance du composant sera passée à la fonction de rappel en tant qu'argument :
+
+``` js
+beforeRouteEnter (to, from, next) {
+  next(vm => {
+    // accès à l'instance du composant via `vm`
+  })
+}
+```
+
+Notez que `beforeRouteEnter` est la seule interception qui supporte une fonction de rappelle dans `next`. Pour `beforeRouteUpdate` et `beforeRouteLeave`, `this` est déjà disponible. Le passage d'une fonction de rappel n'étant pas nécessaire, il n'est donc pas *supporté* :
+
+```js
+beforeRouteUpdate (to, from, next) {
+  // utiliser juste `this`
+  this.name = to.params.name
+  next()
+}
+```
+
+L'**interception de sortie** est habituellement utilisée pour empécher l'utilisateur de quitter la route sans avoir sauvegardé ses changements. La navigation peut être annulée en appelant `next(false)`.
+
+```js
+beforeRouteLeave (to, from , next) {
+  const answer = window.confirm('Voulez-vous vraiment quitter cette page ? Vos changements seront perdus.')
+  if (answer) {
+    next()
+  } else {
+    next(false)
+  }
+}
+```
+
+## Le flux de résolution de navigation complet
+
+1. La navigation est demandée.
+2. Appel de l'interception de sortie des composants désactivés (ceux que l'on va quitter).
+3. Appel des interceptions globales `beforeEach`.
+4. Appel des interceptions `beforeRouteUpdate` pour les composants réutilisés (2.2+).
+5. Appel de `beforeEnter` dans la configuration de route.
+6. Résolution des composants de route asynchrones.
+7. Appel de `beforeRouteEnter` dans les composants activés (ceux où l'on va arriver).
+8. Appel des interceptions `beforeResolve` (2.5+).
+9. Confirmation de la navigation.
+10. Appel des hooks globaux `afterEach`.
+11. Modification du DOM demandée.
+12. Appel des fonctions de rappel passées à `next` dans l'interception `beforeRouteEnter` avec l'instance instanciée.

--- a/docs/fr/guide/advanced/navigation-guards.md
+++ b/docs/fr/guide/advanced/navigation-guards.md
@@ -20,7 +20,7 @@ Les interceptions d'entrées globales sont appelées lors de l'ordre de créatio
 
 Chaque fonction d'interception reçoit trois arguments :
 
-- **`to: Route`**: L'[objet `Route`](../../api/#options-de-construction-du-routeur) cible vers lequel on navigue.
+- **`to: Route`**: L'[objet `Route`](../../api/#the-route-object) cible vers lequel on navigue.
 
 - **`from: Route`**: la route courante depuis laquelle nous venons de naviguer.
 
@@ -30,17 +30,15 @@ Chaque fonction d'interception reçoit trois arguments :
 
   - **`next(false)`**: annuler la navigation courante. Si l'URL du navigateur avait changé (manuellement par l'utilisateur ou via le bouton retour du navigateur), il sera remis à sa valeur de route de `from`.
 
-  - **`next('/')` ou `next({ path: '/' })`**: redirige vers le nouvel URL. La navigation courante va être arrêtée et une nouvelle va se lancer. Vous pouvez passer n'importe quel objet à `next`, vous permettant ainsi de spécifier des options comme `replace: true`, `name: 'home'` et n'importe quelles options dans [la prop `to` du `router-link`](../../api/#router-link) ou [`router.push`](../../api/#l-instance-du-routeur).
+  - **`next('/')` ou `next({ path: '/' })`**: redirige vers le nouvel URL. La navigation courante va être arrêtée et une nouvelle va se lancer. Vous pouvez passer n'importe quel objet à `next`, vous permettant ainsi de spécifier des options comme `replace: true`, `name: 'home'` et n'importe quelles options dans [la prop `to` du `router-link`](../../api/#to) ou [`router.push`](../../api/#routeur-push).
 
-  - **`next(error)`**: (2.4.0+) si l'argument passé à `next` est une instance de `Error`, la navigation va s'arrêter et l'erreur sera passée aux fonctions de rappel enregistrées via [`router.onError()`](../../api/#l-instance-du-routeur).
+  - **`next(error)`**: (2.4.0+) si l'argument passé à `next` est une instance de `Error`, la navigation va s'arrêter et l'erreur sera passée aux fonctions de rappel enregistrées via [`router.onError()`](../../api/#router-onerror).
 
 **Assurez-vous de toujours appeler la fonction `next`, sinon le hook ne sera jamais résolu.**
 
 ## Résolutions des interceptions globales
 
-> Nouveau dans la 2.5.0
-
-Dans la 2.5.0+ vous pouvez abonner une interception globale avec `router.beforeResolve`. Ceci est similaire a `router.beforeEach`, mais la différence est qu'elle sera appelée juste après que la navigation soit confirmée, **après que toutes les interceptions par composants et les composants de route asynchrone ait été résolu**.
+Vous pouvez abonner une interception globale avec `router.beforeResolve`. Ceci est similaire a `router.beforeEach`, mais la différence est qu'elle sera appelée juste après que la navigation soit confirmée, **après que toutes les interceptions par composants et les composants de route asynchrone ait été résolu**.
 
 ## Hooks de sortie globaux
 
@@ -77,7 +75,7 @@ Ces interceptions ont exactement le même effet que les interceptions globales d
 Enfin, vous pouvez directement définir une interception de navigation a l'intérieur du composant lui-même (celui passer à la configuration du routeur) avec les options suivantes :
 
 - `beforeRouteEnter`
-- `beforeRouteUpdate` (ajouté dans la 2.2+)
+- `beforeRouteUpdate`
 - `beforeRouteLeave`
 
 ``` js
@@ -142,13 +140,13 @@ beforeRouteLeave (to, from , next) {
 ## Le flux de résolution de navigation complet
 
 1. La navigation est demandée.
-2. Appel de l'interception de sortie des composants désactivés (ceux que l'on va quitter).
+2. Appel de l'interception de sortie des composants désactivés.
 3. Appel des interceptions globales `beforeEach`.
-4. Appel des interceptions `beforeRouteUpdate` pour les composants réutilisés (2.2+).
+4. Appel des interceptions `beforeRouteUpdate` pour les composants réutilisés.
 5. Appel de `beforeEnter` dans la configuration de route.
 6. Résolution des composants de route asynchrones.
-7. Appel de `beforeRouteEnter` dans les composants activés (ceux où l'on va arriver).
-8. Appel des interceptions `beforeResolve` (2.5+).
+7. Appel de `beforeRouteEnter` dans les composants activés.
+8. Appel des interceptions `beforeResolve`.
 9. Confirmation de la navigation.
 10. Appel des hooks globaux `afterEach`.
 11. Modification du DOM demandée.

--- a/docs/fr/guide/advanced/scroll-behavior.md
+++ b/docs/fr/guide/advanced/scroll-behavior.md
@@ -1,0 +1,80 @@
+# Comportement du défilement
+
+En utilisant le routage côté client, nous pourrions vouloir faire défiler la page jusqu'en haut lorsqu'on navigue vers une nouvelle route, ou alors préserver la position du défilement des entrées de l'historique comme le ferait une page réelle. `vue-router` vous permet de faire cela et, encore mieux, vous permet de changer le comportement du défilement pendant la navigation.
+
+**Note : cette fonctionnalité ne fonctionne que si le navigateur supporte `history.pushState`.**
+
+Pendant la création de l'instance du routeur, vous pouvez renseigner la fonction `scrollBehavior` :
+
+``` js
+const router = new VueRouter({
+  routes: [...],
+  scrollBehavior (to, from, savedPosition) {
+    // retourner la position désirée
+  }
+})
+```
+
+La fonction `scrollBehavior` reçoit les objets de route `to` et `from`. Le troisième argument, `savedPosition`, est disponible uniquement si c'est une navigation `popstate` (déclenchée par les boutons précédent/suivant du navigateur).
+
+La fonction peut retourner un objet décrivant la position du défilement. L'objet peut être de la forme :
+
+-  `{ x: number, y: number }`
+- `{ selector: string, offset? : { x: number, y: number }}` (offset seulement supporté pour les versions 2.6.0+)
+
+Si une valeur équivalente à `false` ou un objet vide est retourné, aucun défilement ne sera produit.
+
+Par exemple :
+
+``` js
+scrollBehavior (to, from, savedPosition) {
+  return { x: 0, y: 0 }
+}
+```
+
+Cela permettra de défiler au haut de page à chaque navigation à travers les routes.
+
+Retourner l'objet `savedPosition` résultera en un comportement quasi natif en naviguant avec les boutons précédents/suivants :
+
+``` js
+scrollBehavior (to, from, savedPosition) {
+  if (savedPosition) {
+    return savedPosition
+  } else {
+    return { x: 0, y: 0 }
+  }
+}
+```
+
+Si vous voulez simuler le comportement « aller à l'ancre » :
+
+``` js
+scrollBehavior (to, from, savedPosition) {
+  if (to.hash) {
+    return {
+      selector: to.hash
+      // , offset: { x: 0, y: 10 }
+    }
+  }
+}
+```
+
+On peut aussi utiliser les [champs meta de route](meta.md) pour implémenter un contrôle bien précis pour le comportement du défilement. Allez voir un exemple complet [ici](https://github.com/vuejs/vue-router/blob/dev/examples/scroll-behavior/app.js).
+
+## Défilement asynchrone
+
+> Nouveau dans la 2.8.0+
+
+Vous pouvez également retourner une promesse pour résoudre la description de position souhaitée :
+
+``` js
+scrollBehavior (to, from, savedPosition) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({ x: 0, y: 0 })
+    }, 500)
+  })
+}
+```
+
+Il est possible de relier les événements d'un composant de transition au niveau de la page pour que le comportement de défilement soit bien adapté à vos transitions de pages. Cependant, en raison de la variance et de la complexité des cas d'utilisation, nous fournissons simplement ce code primitif pour permettre aux utilisateurs de faire les implémentations spécifiques.

--- a/docs/fr/guide/advanced/transitions.md
+++ b/docs/fr/guide/advanced/transitions.md
@@ -1,0 +1,58 @@
+# Transitions
+
+Vu que `<router-view>` est essentiellement un composant dynamique, on peut lui appliquer certains effets de transitions en utilisant le composant `<transition>` :
+
+``` html
+<transition>
+  <router-view></router-view>
+</transition>
+```
+
+[Tout à propos de `<transition>`](https://fr.vuejs.org/v2/guide/transitions.html) fonctionne également ici de la même manière.
+
+## Transition par route
+
+L'utilisation du dessus applique la même transition pour chaque route. Si vous voulez que les composants de route aient des transitions différentes, vous pouvez utiliser à la place `<transition>` avec des noms différents à l'intérieur de chaque composant de route :
+
+``` js
+const Foo = {
+  template: `
+    <transition name="slide">
+      <div class="foo">...</div>
+    </transition>
+  `
+}
+
+const Bar = {
+  template: `
+    <transition name="fade">
+      <div class="bar">...</div>
+    </transition>
+  `
+}
+```
+
+## Transition dynamique basée sur la route
+
+Il est aussi possible de déterminer la transition à utiliser en se basant sur la relation entre la route cible et la route actuelle :
+
+``` html
+<!-- utiliser un nom de transition dynamique -->
+<transition :name="transitionName">
+  <router-view></router-view>
+</transition>
+```
+
+``` js
+// et dans le composant parent,
+// observer la `$route` pour déterminer la transition à utiliser
+watch: {
+  '$route' (to, from) {
+    const toDepth = to.path.split('/').length
+    const fromDepth = from.path.split('/').length
+    this.transitionName = toDepth < fromDepth ? 'slide-right' : 'slide-left'
+  }
+}
+```
+
+Voir un exemple complet [ici](https://github.com/vuejs/vue-router/blob/dev/examples/transitions/app.js).

--- a/docs/fr/guide/essentials/dynamic-matching.md
+++ b/docs/fr/guide/essentials/dynamic-matching.md
@@ -34,7 +34,7 @@ Vous pouvez avoir plusieurs segments dynamiques pour une même route, et ils ser
 | /utilisateur/:username | /utilisateur/evan | `{ username: 'evan' }` |
 | /utilisateur/:username/billet/:post_id | /utilisateur/evan/billet/123 | `{ username: 'evan', post_id: 123 }` |
 
-En plus de `$route.params`, l'objet `$route` expose également d'autres informations utiles comme la `$route.query` (s'il y a une requête dans l'URL), `$route.hash`, etc. Vous pouvez accéder à tous les détails de cela dans la [référence de l'API](../../api/#options-de-construction-du-routeur).
+En plus de `$route.params`, l'objet `$route` expose également d'autres informations utiles comme la `$route.query` (s'il y a une requête dans l'URL), `$route.hash`, etc. Vous pouvez accéder à tous les détails de cela dans la [référence de l'API](../../api/#the-route-object).
 
 ## Réactivité aux changements de paramètres
 
@@ -53,7 +53,7 @@ const User = {
 }
 ```
 
-Ou utiliser la fonction d'interception `beforeRouteUpdate` introduite avec la 2.2 :
+Ou utiliser la [fonction d'interception](../advanced/navigation-guards.html) `beforeRouteUpdate` introduite avec la 2.2 :
 
 ``` js
 const User = {

--- a/docs/fr/guide/essentials/dynamic-matching.md
+++ b/docs/fr/guide/essentials/dynamic-matching.md
@@ -1,0 +1,74 @@
+# Concordance dynamique de route
+
+Vous allez très souvent associer des routes avec un motif donné à un même composant. Par exemple nous pourrions avoir le composant `User` qui devrait être rendu pour tous les utilisateurs mais avec différents identifiants. Avec `vue-router` nous pouvons utiliser des segments dynamiques dans le chemin de la route pour réaliser cela :
+
+``` js
+const User = {
+  template: '<div>Utilisateur</div>'
+}
+
+const router = new VueRouter({
+  routes: [
+    // Les segments dynamiques commencent avec la ponctuation deux-points
+    { path: '/utilisateur/:id', component: User }
+  ]
+})
+```
+
+Maintenant des URL comme `/utilisateur/foo` et `/utilisateur/bar` seront chacun associé à la même route.
+
+Un segment dynamique se repère avec les deux-points `:`. Quand une route concorde, la valeur du segment dynamique est exposée via `this.$route.params` dans tous les composants. Et donc, nous pouvons faire le rendu de l'identifiant de l'utilisateur courant en mettant à jour le template de `User` ainsi :
+
+``` js
+const User = {
+  template: '<div>Utilisateur {{ $route.params.id }}</div>'
+}
+```
+
+Vous pouvez regarder un exemple en ligne [ici](https://jsfiddle.net/yyx990803/4xfa2f19/).
+
+Vous pouvez avoir plusieurs segments dynamiques pour une même route, et ils seront associés aux champs associés dans `$route.params`. Des exemples :
+
+| motif | chemin concordant | $route.params |
+|---------|------|--------|
+| /utilisateur/:username | /utilisateur/evan | `{ username: 'evan' }` |
+| /utilisateur/:username/billet/:post_id | /utilisateur/evan/billet/123 | `{ username: 'evan', post_id: 123 }` |
+
+En plus de `$route.params`, l'objet `$route` expose également d'autres informations utiles comme la `$route.query` (s'il y a une requête dans l'URL), `$route.hash`, etc. Vous pouvez accéder à tous les détails de cela dans la [référence de l'API](../../api/#options-de-construction-du-routeur).
+
+## Réactivité aux changements de paramètres
+
+Une chose à noter quand vous utilisez des routes avec des paramètres (segments), c'est que lors de la navigation de l'utilisateur de `/utilisateur/foo` vers `/utilisateur/bar`, **la même instance de composant va être réutilisée**. Puisque les deux routes font le rendu du même composant, cela est plus performant que de détruire l'ancienne instance et d'en créer une nouvelle. **Cependant, cela signifie également que les hooks de cycle de vie ne seront pas appelés**.
+
+Pour réagir aux changements de paramètres dans le même composant, vous pouvez simplement observer l'objet `$route` :
+
+``` js
+const User = {
+  template: '...',
+  watch: {
+    '$route' (to, from) {
+      // réagir au changement de route...
+    }
+  }
+}
+```
+
+Ou utiliser la fonction d'interception `beforeRouteUpdate` introduite avec la 2.2 :
+
+``` js
+const User = {
+  template: '...',
+  beforeRouteUpdate (to, from, next) {
+    // réagir au changement de route...
+    // n'oubliez pas d'appeler `next()`
+  }
+}
+```
+
+## Motifs de concordance avancés
+
+`vue-router` utilise [path-to-regexp](https://github.com/pillarjs/path-to-regexp) comme moteur de concordance de chemin, il supporte donc plusieurs motifs de concordance avancés tels que la présence optionnelle de segments dynamiques, aucun ou plusieurs motifs, plus d'options par motifs, et même des motifs d'expressions régulières personnalisés. Consultez cette [documentation](https://github.com/pillarjs/path-to-regexp#parameters) pour utiliser ces motifs avancés et [cet exemple](https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js) pour les utiliser avec `vue-router`.
+
+## Priorité de concordance
+
+Parfois la même URL peut être adressé par de multiples routes. Dans ce cas, la priorité de concordance est déterminée par l'ordre de la définition des routes : plus la route est définie tôt, plus sa priorité est élevée.

--- a/docs/fr/guide/essentials/history-mode.md
+++ b/docs/fr/guide/essentials/history-mode.md
@@ -1,0 +1,136 @@
+# Mode historique de HTML5
+
+Le mode par défaut de `vue-router` est le _mode hash_. Il utilise la partie hash de l'URL pour simuler un URL complet et ainsi ne pas recharger la page quand l'URL change.
+
+Pour nous passer du hash, nous pouvons utiliser le **mode historique** qui utilisera l'API `history.pushState` afin de permettre une navigation sans rechargement de page :
+
+``` js
+const router = new VueRouter({
+  mode: 'history',
+  routes: [...]
+})
+```
+
+Quand vous utilisez le mode historique, l'URL ressemblera à n'importe quel URL normal. Par ex. `http://oursite.com/user/id`. Magnifique !
+
+Cependant, un problème apparait si votre application est une application monopage cliente. Sans une configuration serveur adaptée, les utilisateurs tomberont sur une page d'erreur 404 en tentant d'accéder à `http://oursite.com/user/id` directement dans leur navigateur. Maintenant ça craint.
+
+Ne vous inquiétez pas. Pour résoudre ce problème, il vous suffit d'ajouter une route à votre serveur prenant en compte toutes les adresses demandées. Si l'URL demandée ne concorde avec aucun fichier statique, alors il doit toujours renvoyer la page `index.html` qui contient le code de votre application. De nouveau magnifique !
+
+## Exemple de configurations serveur
+
+### Apache
+
+```apache
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /index.html [L]
+</IfModule>
+```
+
+### nginx
+
+```nginx
+location / {
+  try_files $uri $uri/ /index.html;
+}
+```
+
+### Node.js natif
+
+```js
+const http = require('http')
+const fs = require('fs')
+const httpPort = 80
+
+http.createServer((req, res) => {
+  fs.readFile('index.htm', 'utf-8', (err, content) => {
+    if (err) {
+      console.log(`Impossible d'ouvrir le fichier "index.htm"`)
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8'
+    })
+
+    res.end(content)
+  })
+}).listen(httpPort, () => {
+  console.log('Le serveur écoute à : http://localhost:%s', httpPort)
+})
+```
+
+### Node.js avec Express
+
+Pour Node.js avec Express, vous pouvez utiliser le [middleware connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback).
+
+### Internet Information Services (IIS)
+
+1. Instaler [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)
+2. Créer un fichier `web.config` dans le répertoire racine de votre site avec le contenu suivant :
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="Handle History Mode and custom 404/500" stopProcessing="true">
+          <match url="(.*)" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>
+```
+
+### Caddy
+
+```
+rewrite {
+    regexp .*
+    to {path} /
+}
+```
+
+### Hébergement Firebase
+
+Ajouter ceci à votre fichier `firebase.json` :
+
+```
+{
+  "hosting": {
+    "public": "dist",
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}
+```
+
+## Limitation
+
+Il y a une limitation a tout ceci. Votre serveur ne renverra plus les erreurs 404 des chemins qui ne sont pas trouvés puisqu'il va servir à présent le fichier `index.html`. Pour contourner ce problème, vous pouvez implémenter une route concordant avec toutes les adresses en 404 dans votre application Vue :
+
+``` js
+const router = new VueRouter({
+  mode: 'history',
+  routes: [
+    { path: '*', component: NotFoundComponent }
+  ]
+})
+```
+
+Une alternative possible, si vous utilisez un serveur Node.js, est d'implémenter ce mécanisme de substitution en utilisant le routeur côté serveur pour vérifier la concordance des demandes d'URL entrant. Si la route ne concorde avec rien, la page est inexistante. Consultez l'[utilisation de Vue côté serveur](https://ssr.vuejs.org/fr/) pour plus d'informations.

--- a/docs/fr/guide/essentials/history-mode.md
+++ b/docs/fr/guide/essentials/history-mode.md
@@ -32,6 +32,8 @@ Ne vous inquiétez pas. Pour résoudre ce problème, il vous suffit d'ajouter un
 </IfModule>
 ```
 
+Instead of `mod_rewrite`, you could also use [`FallbackResource`](https://httpd.apache.org/docs/2.2/mod/mod_dir.html#fallbackresource).
+
 ### nginx
 
 ```nginx

--- a/docs/fr/guide/essentials/named-routes.md
+++ b/docs/fr/guide/essentials/named-routes.md
@@ -1,0 +1,31 @@
+# Routes nommées
+
+Parfois il est plus pratique d'identifier une route avec un nom, tout particulièrement quand on souhaite attacher cette route ou exécuter des actions de navigation. Vous pouvez donner un nom à une route dans les options `routes` pendant la création de l'instance du routeur :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/utilisateur/:userId',
+      name: 'user',
+      component: User
+    }
+  ]
+})
+```
+
+Pour attacher une route nommée, vous pouvez passer un objet à la prop `to` du composant `router-link` :
+
+``` html
+<router-link :to="{ name: 'user', params: { userId: 123 }}">Utilisateur</router-link>
+```
+
+C'est exactement le même objet à utiliser programmatiquement avec `router.push()` :
+
+``` js
+router.push({ name: 'user', params: { userId: 123 }})
+```
+
+Dans les deux cas, le routeur va naviguer vers le chemin `/utilisateur/123`.
+
+Un exemple complet se trouve [ici](https://github.com/vuejs/vue-router/blob/dev/examples/named-routes/app.js).

--- a/docs/fr/guide/essentials/named-views.md
+++ b/docs/fr/guide/essentials/named-views.md
@@ -1,0 +1,86 @@
+# Vues nommées
+
+Parfois vous avez besoin d'afficher différentes vues en même temps plutôt que de les imbriquer, c.-à-d. créer un affichage avec une vue `sidebar` et une vue `main` par exemple. C'est ici que les routes nommées entrent en jeu. Au lieu d'avoir une seule balise de vue, vous pouvez en avoir une multitude et donner à chacune d'entre elles un nom. Un `router-view` sans nom aura comme nom par défaut : `default`.
+
+``` html
+<router-view class="view one"></router-view>
+<router-view class="view two" name="a"></router-view>
+<router-view class="view three" name="b"></router-view>
+```
+
+Une vue est rendue en utilisant un composant, donc de multiples vues nécessitent de multiples composants pour une même route. Assurez-vous d'utiliser l'option `components` (avec un s) :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/',
+      components: {
+        default: Foo,
+        a: Bar,
+        b: Baz
+      }
+    }
+  ]
+})
+```
+
+Une démo de cet exemple peut-être trouvée [ici](https://jsfiddle.net/posva/6du90epg/).
+
+## Vues nommées imbriquées
+
+Il est possible de créer des dispositions complexes en utilisant les vues nommées avec les vues imbriquées. Quand vous le faites, vous devez nommer les composants imbriqués de `router-view` utilisés. Voyons cela avec un panneau de configuration exemple :
+
+```
+/parametres/emails                                     /parametres/profile
++-----------------------------------+                  +------------------------------+
+| UserSettings                      |                  | UserSettings                 |
+| +-----+-------------------------+ |                  | +-----+--------------------+ |
+| | Nav | UserEmailsSubscriptions | |  +------------>  | | Nav | UserProfile        | |
+| |     +-------------------------+ |                  | |     +--------------------+ |
+| |     |                         | |                  | |     | UserProfilePreview | |
+| +-----+-------------------------+ |                  | +-----+--------------------+ |
++-----------------------------------+                  +------------------------------+
+```
+
+- `Nav` est juste un composant standard.
+- `UserSettings` est un composant de vue.
+- `UserEmailsSubscriptions`, `UserProfile`, `UserProfilePreview` sont des composants de vue imbriqués.
+
+**Note** : _mettons de côté la partie HTML / CSS de cette disposition et concentrons nous sur le composant utilisé en lui-même._
+
+La section `<template>` pour le composant `UserSettings` de la disposition ci-dessus devrait ressembler à quelque chose comme cela :
+
+```html
+<!-- UserSettings.vue -->
+<div>
+  <h1>Paramètres utilisateurs</h1>
+  <NavBar/>
+  <router-view/>
+  <router-view name="helper"/>
+</div>
+```
+
+_Le composant de vue imbriqué est omis ici mais vous pouvez le trouver dans le code source complet de l'exemple ci-dessus [ici](https://jsfiddle.net/posva/22wgksa3/)._
+
+Puis vous pouvez achever la disposition ci-dessus avec la configuration de route :
+
+```js
+{
+  path: '/parametres',
+  // Vous pouvez également avoir des vues nommées à la racine
+  component: UserSettings,
+  children: [{
+    path: 'emails',
+    component: UserEmailsSubscriptions
+  }, {
+    path: 'profile',
+    components: {
+      default: UserProfile,
+      helper: UserProfilePreview
+    }
+  }]
+}
+```
+
+Une démo de cet exemple peut-être trouvée [ici](https://jsfiddle.net/posva/22wgksa3/).

--- a/docs/fr/guide/essentials/navigation.md
+++ b/docs/fr/guide/essentials/navigation.md
@@ -1,3 +1,7 @@
+---
+sidebarDepth: 0
+---
+
 # Navigation programmatique
 
 En complément du l'utilisation de `<router-link>` pour créer des balises ancres pour la navigation déclarative, nous pouvons le faire de manière programmatique en utilisant les méthodes de l'instance du routeur.
@@ -44,7 +48,7 @@ Les mêmes règles s'appliquent pour la propriété `to` du composant `router-li
 
 Dans la version 2.2.0+, vous pouvez optionnellement fournir les fonctions de rappel `onComplete` et `onAbort` à `router.push` ou `router.replace` en tant que deuxième et troisième arguments. Ces fonctions de rappel seront appelées quand la navigation sera respectivement ; complétée avec succès (après la résolution de tous les hooks asynchrones), ou arrêtée (navigation vers la même route ou vers une route différente avant que la navigation courante ne soit achevée).
 
-**Note :** si la destination est la même que la route courante et que seuls les paramètres ont changés (par ex. naviguer d'un profil à l'autre `/utilisateurs/1` -> `/utilisateurs/2`), vous devrez utiliser [`beforeRouteUpdate`](./dynamic-matching.html#réactivité-aux-changements-de-paramètres) pour réagir aux changements (par ex. récupérer les informations de l'utilisateur).
+**Note :** si la destination est la même que la route courante et que seuls les paramètres ont changés (par ex. naviguer d'un profil à l'autre `/utilisateurs/1` -> `/utilisateurs/2`), vous devrez utiliser [`beforeRouteUpdate`](./dynamic-matching.md#réactivité-aux-changements-de-paramètres) pour réagir aux changements (par ex. récupérer les informations de l'utilisateur).
 
 ## `router.replace(location, onComplete?, onAbort?)`
 
@@ -82,4 +86,4 @@ Vous avez peut être remarqué que `router.push`, `router.replace` et `router.go
 
 Donc, si vous utilisez déjà l'[API History des navigateurs](https://developer.mozilla.org/fr-FR/docs/Web/API/History_API), manipuler l'historique sera très simple avec vue-router.
 
-Il n'est pas nécessaire de préciser que les méthodes de navigation (`push`, `replace`, `go`) fonctionnent de la même manière dans tous les modes de routage (`history`, `hash` and `abstract`).
+Il n'est pas nécessaire de préciser que les méthodes de navigation (`push`, `replace`, `go`) fonctionnent de la même manière dans tous les modes de routage (`history`, `hash` et `abstract`).

--- a/docs/fr/guide/essentials/navigation.md
+++ b/docs/fr/guide/essentials/navigation.md
@@ -1,0 +1,85 @@
+# Navigation programmatique
+
+En complément du l'utilisation de `<router-link>` pour créer des balises ancres pour la navigation déclarative, nous pouvons le faire de manière programmatique en utilisant les méthodes de l'instance du routeur.
+
+#### `router.push(location, onComplete?, onAbort?)`
+
+**Note : Dans une instance Vue, vous pouvez accéder à l'instance du routeur via `$router`. Vous pouvez donc appeler `this.$router.push`.**
+
+Pour naviguer vers un URL différent, utilisez `router.push`. Cette méthode ajoute une nouvelle entrée dans la pile de l'historique. Ainsi quand un utilisateur clique sur le bouton retour de son navigateur, il retournera à l'URL précédent.
+
+Cette méthode est appelée en interne quand vous cliquez sur `<router-link>`, donc cliquer sur `<router-link :to="...">` est équivalent à appeler `router.push(...)`.
+
+| Déclarative | Programmatique |
+|-------------|--------------|
+| `<router-link :to="...">` | `router.push(...)` |
+
+L'argument peut être une chaine de caractère représentant un chemin, ou un objet de description de destination. Des exemples :
+
+``` js
+// chaine de caractère représentant un chemin
+router.push('home')
+
+// objet
+router.push({ path: 'home' })
+
+// route nommée
+router.push({ name: 'user', params: { userId: 123 }})
+
+// avec une requête « query » résultant de `/register?plan=private`
+router.push({ path: 'register', query: { plan: 'private' }})
+```
+
+**Note :** `params` est ignoré si `path` est fourni, ce qui n'est pas le cas pour `query`, comme démontré dans l'exemple ci-dessous. À la place, vous devez fournir le `name` de la route ou manuellement spécifier le `path` complet avec tous les paramètres :
+
+```js
+const userId = 123
+router.push({ name: 'user', params: { userId }}) // -> /user/123
+router.push({ path: `/user/${userId}` }) // -> /user/123
+// Ceci ne va PAS fonctionner
+router.push({ path: '/user', params: { userId }}) // -> /user
+```
+
+Les mêmes règles s'appliquent pour la propriété `to` du composant `router-link`.
+
+Dans la version 2.2.0+, vous pouvez optionnellement fournir les fonctions de rappel `onComplete` et `onAbort` à `router.push` ou `router.replace` en tant que deuxième et troisième arguments. Ces fonctions de rappel seront appelées quand la navigation sera respectivement ; complétée avec succès (après la résolution de tous les hooks asynchrones), ou arrêtée (navigation vers la même route ou vers une route différente avant que la navigation courante ne soit achevée).
+
+**Note :** si la destination est la même que la route courante et que seuls les paramètres ont changés (par ex. naviguer d'un profil à l'autre `/utilisateurs/1` -> `/utilisateurs/2`), vous devrez utiliser [`beforeRouteUpdate`](./dynamic-matching.html#réactivité-aux-changements-de-paramètres) pour réagir aux changements (par ex. récupérer les informations de l'utilisateur).
+
+## `router.replace(location, onComplete?, onAbort?)`
+
+Il agit comme `router.push`. La seule différence est que la navigation se fait sans ajouter de nouvelle entrée dans la pile de l'historique. Comme son nom l'indique, il remplace l'entrée courante.
+
+| Déclarative | Programmatique |
+|-------------|--------------|
+| `<router-link :to="..." replace>` | `router.replace(...)` |
+
+
+## `router.go(n)`
+
+Cette méthode prend un seul nombre en tant que paramètre. Celui-ci indique de combien d'entrées vers l'avant ou vers l'arrière il faut naviguer dans la pile de l'historique, de la même manière qu'avec `window.history.go(n)`.
+
+Des exemples
+
+``` js
+// avancer d'une entrée, identique à `history.forward()`
+router.go(1)
+
+// retourner d'une entrée en arrière, identique à `history.back()`
+router.go(-1)
+
+// avancer de trois entrées
+router.go(3)
+
+// échoue silencieusement s'il n'y a pas assez d'entrées.
+router.go(-100)
+router.go(100)
+```
+
+## Manipulation de l'historique
+
+Vous avez peut être remarqué que `router.push`, `router.replace` et `router.go` sont des équivalents de [`window.history.pushState`, `window.history.replaceState` et `window.history.go`](https://developer.mozilla.org/fr-FR/docs/Web/API/History), et qu'ils imitent les APIs de `window.history`.
+
+Donc, si vous utilisez déjà l'[API History des navigateurs](https://developer.mozilla.org/fr-FR/docs/Web/API/History_API), manipuler l'historique sera très simple avec vue-router.
+
+Il n'est pas nécessaire de préciser que les méthodes de navigation (`push`, `replace`, `go`) fonctionnent de la même manière dans tous les modes de routage (`history`, `hash` and `abstract`).

--- a/docs/fr/guide/essentials/nested-routes.md
+++ b/docs/fr/guide/essentials/nested-routes.md
@@ -1,0 +1,99 @@
+# Routes imbriquées
+
+Les vraies interfaces utilisateurs d'application sont faites de composants imbriqués à de multiples niveaux de profondeur. Il est aussi très commun que les segments d'URL correspondent à une certaine structure de composants imbriqués, par exemple :
+
+```
+/utilisateur/foo/profil                  /utilisateur/foo/billets
++---------------------+                  +--------------------+
+| User                |                  | User               |
+| +-----------------+ |                  | +----------------+ |
+| | Profile         | |  +------------>  | | Posts          | |
+| |                 | |                  | |                | |
+| +-----------------+ |                  | +----------------+ |
++---------------------+                  +--------------------+
+```
+
+Avec `vue-router`, il est vraiment très simple d'exprimer cette relation en utilisant des configurations de route imbriquées.
+
+Reprenons l'application créée au chapitre précédent :
+
+``` html
+<div id="app">
+  <router-view></router-view>
+</div>
+```
+
+``` js
+const User = {
+  template: '<div>Utilisateur {{ $route.params.id }}</div>'
+}
+
+const router = new VueRouter({
+  routes: [
+    { path: '/utilisateur/:id', component: User }
+  ]
+})
+```
+
+Ici le `<router-view>` est une balise de premier niveau. Il fait le rendu des composants qui concordent avec une route de premier niveau. De la même façon, un composant de rendu peut contenir également sa propre balise `<router-view>` imbriquée. Par exemple, ajoutons en une à l'intérieur du template du composant `User` :
+
+``` js
+const User = {
+  template: `
+    <div class="user">
+      <h2>Utilisateur {{ $route.params.id }}</h2>
+      <router-view></router-view>
+    </div>
+  `
+}
+```
+
+Pour faire le rendu de composants à l'intérieur des balises imbriquées, nous avons besoin d'utiliser l'option `children` dans la configuration du constructeur de `VueRouter` :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/utilisateur/:id', component: User,
+      children: [
+        {
+          // `UserProfile` va être rendu à l'intérieur du `<router-view>` de `User`
+          // quand `/utilisateur/:id/profil` concorde
+          path: 'profile',
+          component: UserProfile
+        },
+        {
+          // `UserPosts` va être rendu à l'intérieur du `<router-view>` de `User`
+          // quand `/utilisateur/:id/billets` concorde
+          path: 'posts',
+          component: UserPosts
+        }
+      ]
+    }
+  ]
+})
+```
+
+**Notez que les chemins imbriqués commençants par `/` vont être traités comme des chemins partant de la racine. Cela vous permet d'adresser des composants imbriqués sans avoir à utiliser un URL imbriqué.**
+
+Comme vous pouvez le voir, l'option `children` n'est qu'un autre tableau d'objet de configuration de route comme dans `routes`. Et donc, vous pouvez garder les vues imbriquées au plus près de vos besoins.
+
+À ce niveau, avec la configuration ci-dessus, quand vous visitez `/utilisateur/foo`, rien ne sera rendu dans la partie `User`, car aucune sous route ne concorde. Peut-être voudriez-vous afficher quelque chose ici. Dans ce cas, vous pouvez fournir une sous route vide :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/utilisateur/:id', component: User,
+      children: [
+        // `UserProfile` va être rendu à l'intérieur du `<router-view>` de `User`
+        // quand `/utilisateur/:id` concorde
+        { path: '', component: UserHome },
+
+        // ...autres sous routes
+      ]
+    }
+  ]
+})
+```
+
+Une démo de fonctionnement de cet exemple peut-être trouvée [ici](https://jsfiddle.net/yyx990803/L7hscd8h/).

--- a/docs/fr/guide/essentials/passing-props.md
+++ b/docs/fr/guide/essentials/passing-props.md
@@ -1,0 +1,75 @@
+# Passage de props aux composants de route
+
+Utiliser `$route` dans vos composants crée un couplage fort à la route qui va limiter la flexibilité du composant qui ne pourra être utilisé que par certains URL.
+
+Pour découpler un composant de son routeur, utilisez les props :
+
+**Plutôt que de coupler avec `$route`**
+
+``` js
+const User = {
+  template: '<div>Utilisateur {{ $route.params.id }}</div>'
+}
+const router = new VueRouter({
+  routes: [
+    { path: '/utilisateur/:id', component: User }
+  ]
+})
+```
+
+**Découplez avec les `props`**
+
+``` js
+const User = {
+  props: ['id'],
+  template: '<div>Utilisateur {{ id }}</div>'
+}
+const router = new VueRouter({
+  routes: [
+    { path: '/utilisateur/:id', component: User, props: true },
+
+    // pour les routes avec vues nommées, vous devez définir l'option `props` pour chaque vue nommée :
+    {
+      path: '/utilisateur/:id',
+      components: { default: User, sidebar: Sidebar },
+      props: { default: true, sidebar: false }
+    }
+  ]
+})
+```
+
+Cela vous permet d'utiliser le composant n'importe où, ce qui le rend plus facile à réutiliser et à tester.
+
+## Mode booléen
+
+Quand `props` est mis à `true`, le `route.params` est remplis en tant que props du composant.
+
+## Mode objet
+
+Quand `props` est un objet, cela alimente les props de celui-ci. Utile quand les props sont statiques.
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/promotion/from-newsletter', component: Promotion, props: { newsletterPopup: false } }
+  ]
+})
+```
+
+## Mode fonction
+
+Vous pouvez créer une fonction qui va retourner les props. Cela vous permet de caster des paramètres dans un autre type, de combiner les valeurs statiques avec les valeurs des routes, etc.
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/search', component: SearchUser, props: (route) => ({ query: route.query.q }) }
+  ]
+})
+```
+
+L'URL `/search?q=vue` passerait `{query: 'vue'}` comme `props` au composant `SearchUser`.
+
+Essayez de garder la fonction de `props` sans état, car il n'est évalué que sur les changements de route. Utilisez un composant englobant si vous avez besoin d'état pour définir les props, ainsi la vue pourra réagir au changement d'état.
+
+Pour une utilisation avancée, jetez un œil à cet [exemple](https://github.com/vuejs/vue-router/blob/dev/examples/route-props/app.js).

--- a/docs/fr/guide/essentials/redirect-and-alias.md
+++ b/docs/fr/guide/essentials/redirect-and-alias.md
@@ -1,0 +1,60 @@
+# Redirection et alias
+
+## Redirection
+
+Les redirections peuvent aussi être faites depuis la configuration de `routes`. Pour rediriger `/a` vers `/b` :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/a', redirect: '/b' }
+  ]
+})
+```
+
+La redirection peut également être effectuée en ciblant une route nommée :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/a', redirect: { name: 'foo' }}
+  ]
+})
+```
+
+Ou on peut même utiliser une fonction pour les redirections dynamiques :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/a', redirect: to => {
+      // la fonction reçoit la route cible en tant qu'argument
+      // retournez le chemin vers la nouvelle route ici.
+    }}
+  ]
+})
+```
+
+Notez que les [intercepteurs de navigation](../advanced/navigation-guards.md) ne sont pas appliqués sur les routes d'où à lieu la redirection mais uniquement sur les routes cibles. Dans l'exemple ci-dessous, ajouter une interception `beforeEnter` ou `beforeLeave` à la route `/a` n'aura aucun effet.
+
+Pour d'autres utilisations avancées, jetez un œil à cet [exemple](https://github.com/vuejs/vue-router/blob/dev/examples/redirect/app.js).
+
+## Alias
+
+Une redirection signifie que si l'utilisateur visite `/a`, l'URL va être remplacé par `/b` et concordé avec `/b`. Mais qu'est-ce qu'un alias ?
+
+** Un alias de `/a` en tant que `/b` signifie que lorsque l'utilisateur va visiter `/b`, l'URL va rester `/b`, mais la concordance va se faire comme si l'utilisateur visitait `/a`.**
+
+La phase du dessus peut être exprimée dans la configuration de la route de la manière suivante :
+
+``` js
+const router = new VueRouter({
+  routes: [
+    { path: '/a', component: A, alias: '/b' }
+  ]
+})
+```
+
+Un alias vous donne la liberté d'associer une structure d'interface utilisateur à un URL arbitraire, au lieu d'être contraint par une configuration de structure.
+
+Pour d'autres utilisations avancées, jetez un œil à cet [exemple](https://github.com/vuejs/vue-router/blob/dev/examples/route-alias/app.js).

--- a/docs/fr/installation.md
+++ b/docs/fr/installation.md
@@ -1,0 +1,44 @@
+# Installation
+
+## Téléchargement direct / CDN
+
+[https://unpkg.com/vue-router/dist/vue-router.js](https://unpkg.com/vue-router/dist/vue-router.js)
+
+<!--email_off-->
+[Unpkg.com](https://unpkg.com) fournit des liens CDN basés sur npm. Le lien ci-dessus pointera toujours vers la dernière version sur npm. Vous pouvez aussi utiliser un tag ou une version spécifique via un URL comme `https://unpkg.com/vue-router@2.0.0/dist/vue-router.js`.
+<!--/email_off-->
+
+Incluez `vue-router` après Vue et l'installation sera automatique :
+
+``` html
+<script src="/path/to/vue.js"></script>
+<script src="/path/to/vue-router.js"></script>
+```
+
+## npm
+
+``` bash
+npm install vue-router
+```
+
+Lorsqu'il est utilisé avec un système de module, vous devez explicitement installer le router via `Vue.use()` :
+
+``` js
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+Vue.use(VueRouter)
+```
+
+Vous n'avez pas besoin de faire cela lors de l'utilisation des balises de script globales (`<script>`).
+
+## Build de développement
+
+Vous aurez besoin de cloner directement `vue-router` depuis GitHub et le compiler vous-même si vous souhaitez utiliser le dernier build de développement.
+
+``` bash
+git clone https://github.com/vuejs/vue-router.git node_modules/vue-router
+cd node_modules/vue-router
+npm install
+npm run build
+```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

The french doc translation was hidden in the previous gitbook configuration.
This heavy PR moves all the files to the vuepress config.

- [x] define fr-FR language in conf
- [x] move gitbook doc in vuepress
- [x] reshape API page to match vuepress structure

😸 Sorry for the long PR, it is mainly doc duplication

Should the French gitbook documentation be removed ?