### PR TITLE
fix: expect 0 to be defined

### DIFF
--- a/src/util/params.js
+++ b/src/util/params.js
@@ -17,11 +17,18 @@ export function fillParams (
     const filler =
       regexpCompileCache[path] ||
       (regexpCompileCache[path] = Regexp.compile(path))
+    if (params && params.pathMatch) {
+      params[0] = params.pathMatch
+    }
     return filler(params || {}, { pretty: true })
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
       warn(false, `missing param for ${routeMsg}: ${e.message}`)
     }
     return ''
+  } finally {
+    if (params && params[0]) {
+      delete params[0]
+    }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Try to fix #2505, delegate `params['pathMatch']` to `params['0']` for `pathToRegexp` package matching.