### PR TITLE
Prevent exceptions when a consumer calls `isSameRoute` with falsey `a`

### DIFF
--- a/src/util/route.js
+++ b/src/util/route.js
@@ -73,7 +73,7 @@ function getFullPath (
 export function isSameRoute (a: Route, b: ?Route): boolean {
   if (b === START) {
     return a === b
-  } else if (!b) {
+  } else if (!a || !b) {
     return false
   } else if (a.path && b.path) {
     return (

--- a/test/unit/specs/route.spec.js
+++ b/test/unit/specs/route.spec.js
@@ -66,6 +66,16 @@ describe('Route utils', () => {
       expect(isSameRoute(a, b)).toBe(true)
       expect(isSameRoute(a, c)).toBe(false)
     })
+
+    it('handles cases where the a route is falsey', () => {
+      const a = undefined
+      const b = {
+        name: 'a',
+        hash: '#hi',
+        query: { arr: ['1', '2'], foo: 'bar' }
+      }
+      expect(isSameRoute(a, b)).toBe(false)
+    })
   })
 
   describe('isIncludedRoute', () => {


### PR DESCRIPTION
In certain cases, I've encountered an exception where `isSameRoute` is
called by an upstream consumer where a is undefined. This is despite the
fact that the type declaration explicitely prohibits such a thing.

Unfortunately, due to my own incompetence at reading the way the vue
error handling stack works; I've been unable to isolate the *caller*.

So, I've added a test case where `a` is a falsey value; in the hope that
this will prevent an exception from being raised, which was triggering
an infinite loop in my particular case; which, again unfortunately, I couldn't figure
out higher up the stack.

Since this is possibly a bug in the calling library, I'm not really
sure it's worth fixing here; but if it is fixed here it'd save me a few
more hours or days of debugging.

Further, I've been unable to create an isolated use case; as my app relies on a number of plugins and middleware with NuxtJS and reproducing it outside of the app I'm working with (Sadly) seems like another huge time sink.

If you'd like, I can try to convince my client to invest the time to resolving the error in a more appropriate manner, otherwise I'll likely wind up needing to rely on a forked version of vue-router :/.