### PR TITLE
docs: add search

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,6 +34,10 @@ module.exports = {
   serviceWorker: true,
   theme: 'vue',
   themeConfig: {
+    algolia: {
+      apiKey: 'f854bb46d3de7eeb921a3b9173bd0d4c',
+      indexName: 'vue-router',
+    },
     repo: 'vuejs/vue-router',
     docsDir: 'docs',
     locales: {


### PR DESCRIPTION
I enabled the Algolia DocSearch crawler on this site, like on other Vue utilities, so that we can search in the bodies of the documentation too!

fixes #2439

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
