### PR TITLE
fix(match): Optional params kept when opening nested route (fix #2110)

### DIFF
--- a/examples/global.css
+++ b/examples/global.css
@@ -7,7 +7,7 @@ html, body {
   padding: 0 20px;
 }
 
-ul {
+ul, ol {
   line-height: 1.5em;
   padding-left: 1.5em;
 }

--- a/examples/nested-routes/app.js
+++ b/examples/nested-routes/app.js
@@ -44,6 +44,17 @@ const Zap = {
   template: '<div><h3>zap</h3><pre>{{ $route.params.zapId }}</pre></div>'
 }
 
+const Fox = {
+  template: `
+    <div>
+      <h3>fox</h3>
+      <pre>{{ $route.params.paramOptional }}</pre>
+      <router-link class="optional-param-nested" :to="{ name: 'foxy' }">Child with optional param in parent</router-link>
+      <router-view class="optional-param-nested-child"></router-view>
+    </div>`
+}
+const Foxy = { template: '<div><h3>foxy</h3><pre>{{ $route.params.paramOptional }}</pre></div>' }
+
 const router = new VueRouter({
   mode: 'history',
   base: __dirname,
@@ -80,7 +91,14 @@ const router = new VueRouter({
 
         { path: 'quy/:quyId', component: Quy },
 
-        { name: 'zap', path: 'zap/:zapId?', component: Zap }
+        { name: 'zap', path: 'zap/:zapId?', component: Zap },
+
+        {
+          name: 'fox',
+          path: 'fox/:param1/:paramOptional?/:param2',
+          component: Fox,
+          children: [{ path: 'foxy', name: 'foxy', component: Foxy }]
+        }
       ]
     }
   ]
@@ -103,6 +121,7 @@ new Vue({
         <li><router-link :to="{ params: { zapId: 2 }}">{ params: { zapId: 2 }} (relative params)</router-link></li>
         <li><router-link to="/parent/qux/1/quux">/parent/qux/1/quux</router-link></li>
         <li><router-link to="/parent/qux/2/quux">/parent/qux/2/quux</router-link></li>
+        <li><router-link :to="{ name: 'fox', params: { param1: 1, param2: 2, paramOptional: 'optional' }}">/fox/:param1/:paramOptional?/:param2</router-link></li>
       </ul>
       <router-view class="view"></router-view>
     </div>

--- a/examples/nested-routes/app.js
+++ b/examples/nested-routes/app.js
@@ -41,7 +41,7 @@ const Quux = {
 }
 const Quuy = { template: '<div>quuy</div>' }
 const Zap = {
-  template: '<div><h3>zap</h3><pre>{{ $route.params.zapId }}</pre></div>'
+  template: '<div><h3>zap</h3><pre>{{ $route.params.zapId }}</pre> <span id="hasZapParam">{{ "zapId" in $route.params }}</span></div>'
 }
 
 const Fox = {
@@ -109,7 +109,7 @@ new Vue({
   template: `
     <div id="app">
       <h1>Nested Routes</h1>
-      <ul>
+      <ol>
         <li><router-link to="/parent">/parent</router-link></li>
         <li><router-link to="/parent/foo">/parent/foo</router-link></li>
         <li><router-link to="/parent/bar">/parent/bar</router-link></li>
@@ -122,7 +122,7 @@ new Vue({
         <li><router-link to="/parent/qux/1/quux">/parent/qux/1/quux</router-link></li>
         <li><router-link to="/parent/qux/2/quux">/parent/qux/2/quux</router-link></li>
         <li><router-link :to="{ name: 'fox', params: { param1: 1, param2: 2, paramOptional: 'optional' }}">/fox/:param1/:paramOptional?/:param2</router-link></li>
-      </ul>
+      </ol>
       <router-view class="view"></router-view>
     </div>
   `

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -4,7 +4,7 @@ import type VueRouter from './index'
 import { resolvePath } from './util/path'
 import { assert, warn } from './util/warn'
 import { createRoute } from './util/route'
-import { fillParams, parentHasOptionalParams } from './util/params'
+import { fillParams } from './util/params'
 import { createRouteMap } from './create-route-map'
 import { normalizeLocation } from './util/location'
 
@@ -37,18 +37,10 @@ export function createMatcher (
         warn(record, `Route with name '${name}' does not exist`)
       }
       if (!record) return _createRoute(null, location)
-      let paramNames = record.regex.keys
-        .filter(key => !key.optional)
-        .map(key => key.name)
+      const paramNames = record.regex.keys.map(key => key.name)
 
       if (typeof location.params !== 'object') {
         location.params = {}
-      }
-
-      if (record.parent && record.parent.regex && record.parent.regex.keys && parentHasOptionalParams(record.parent)) {
-        paramNames = paramNames.concat(record.parent.regex.keys
-          .filter(key => key.optional)
-          .map(key => key.name))
       }
 
       if (currentRoute && typeof currentRoute.params === 'object') {
@@ -192,7 +184,7 @@ function matchRoute (
   for (let i = 1, len = m.length; i < len; ++i) {
     const key = regex.keys[i - 1]
     const val = typeof m[i] === 'string' ? decodeURIComponent(m[i]) : m[i]
-    if (key) {
+    if (key && val != null) {
       // Fix #1994: using * with props: true generates a param named 0
       params[key.name || 'pathMatch'] = val
     }

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -4,7 +4,7 @@ import type VueRouter from './index'
 import { resolvePath } from './util/path'
 import { assert, warn } from './util/warn'
 import { createRoute } from './util/route'
-import { fillParams } from './util/params'
+import { fillParams, parentHasOptionalParams } from './util/params'
 import { createRouteMap } from './create-route-map'
 import { normalizeLocation } from './util/location'
 
@@ -37,12 +37,18 @@ export function createMatcher (
         warn(record, `Route with name '${name}' does not exist`)
       }
       if (!record) return _createRoute(null, location)
-      const paramNames = record.regex.keys
+      let paramNames = record.regex.keys
         .filter(key => !key.optional)
         .map(key => key.name)
 
       if (typeof location.params !== 'object') {
         location.params = {}
+      }
+
+      if (record.parent && record.parent.regex && record.parent.regex.keys && parentHasOptionalParams(record.parent)) {
+        paramNames = paramNames.concat(record.parent.regex.keys
+          .filter(key => key.optional)
+          .map(key => key.name))
       }
 
       if (currentRoute && typeof currentRoute.params === 'object') {

--- a/src/util/params.js
+++ b/src/util/params.js
@@ -35,14 +35,3 @@ export function fillParams (
     delete params[0]
   }
 }
-
-export function parentHasOptionalParams (
-  record: Object): boolean {
-  if (record.regex) {
-    if (record.parent) {
-      return (record.regex.keys && record.regex.keys.filter(key => key.optional)[0]) || parentHasOptionalParams(record.parent)
-    }
-    return record.regex.keys && record.regex.keys.filter(key => key.optional)[0]
-  }
-  return false
-}

--- a/src/util/params.js
+++ b/src/util/params.js
@@ -40,9 +40,9 @@ export function parentHasOptionalParams (
   record: Object): boolean {
   if (record.regex) {
     if (record.parent) {
-      return (record.regex.keys && record.regex.keys.find(key => key.optional)) || parentHasOptionalParams(record.parent)
+      return (record.regex.keys && record.regex.keys.filter(key => key.optional)[0]) || parentHasOptionalParams(record.parent)
     }
-    return record.regex.keys && record.regex.keys.find(key => key.optional)
+    return record.regex.keys && record.regex.keys.filter(key => key.optional)[0]
   }
   return false
 }

--- a/src/util/params.js
+++ b/src/util/params.js
@@ -35,3 +35,14 @@ export function fillParams (
     delete params[0]
   }
 }
+
+export function parentHasOptionalParams (
+  record: Object): boolean {
+  if (record.regex) {
+    if (record.parent) {
+      return (record.regex.keys && record.regex.keys.find(key => key.optional)) || parentHasOptionalParams(record.parent)
+    }
+    return record.regex.keys && record.regex.keys.find(key => key.optional)
+  }
+  return false
+}

--- a/test/e2e/specs/nested-routes.js
+++ b/test/e2e/specs/nested-routes.js
@@ -55,6 +55,28 @@ module.exports = {
         'quyId'
       )
 
+      // initial navigation should not have optional params
+      .url('http://localhost:8080/nested-routes/parent/zap')
+      .assert.containsText('.view', 'Parent')
+      .assert.containsText('.view', 'zap')
+      .assert.containsText('#hasZapParam', 'false')
+      // go somewhere else
+      .click('li:nth-child(1) a')
+
+      .click('li:nth-child(7) a')
+      .assert.urlEquals('http://localhost:8080/nested-routes/parent/zap')
+      .assert.containsText('.view', 'Parent')
+      .assert.containsText('.view', 'zap')
+      .assert.containsText('#hasZapParam', 'false')
+      .assert.evaluate(
+        function () {
+          var zapId = document.querySelector('pre').textContent
+          return zapId === ''
+        },
+        null,
+        'optional zapId'
+      )
+
       .click('li:nth-child(8) a')
       .assert.urlEquals('http://localhost:8080/nested-routes/parent/zap/1')
       .assert.containsText('.view', 'Parent')
@@ -68,10 +90,8 @@ module.exports = {
         'zapId'
       )
 
-      .click('li:nth-child(7) a')
+      .back()
       .assert.urlEquals('http://localhost:8080/nested-routes/parent/zap')
-      .assert.containsText('.view', 'Parent')
-      .assert.containsText('.view', 'zap')
       .assert.evaluate(
         function () {
           var zapId = document.querySelector('pre').textContent
@@ -108,6 +128,7 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/nested-routes/parent/fox/1/optional/2/foxy')
       .assert.containsText('.optional-param-nested-child pre', 'optional')
 
+      // check initial visit
       .url('http://localhost:8080/nested-routes/parent/foo')
       .waitForElementVisible('#app', 1000)
       .assert.containsText('.view', 'Parent')

--- a/test/e2e/specs/nested-routes.js
+++ b/test/e2e/specs/nested-routes.js
@@ -9,7 +9,7 @@ module.exports = {
     browser
       .url('http://localhost:8080/nested-routes/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 11)
+      .assert.count('li a', 12)
       .assert.urlEquals('http://localhost:8080/nested-routes/parent')
       .assert.containsText('.view', 'Parent')
       .assert.containsText('.view', 'default')
@@ -99,7 +99,15 @@ module.exports = {
       .click('.nested-child a')
       .assert.urlEquals('http://localhost:8080/nested-routes/parent/qux/2/quuy')
 
-      // check initial visit
+      // test optional params
+      .click('li:nth-child(12) a')
+      .assert.urlEquals('http://localhost:8080/nested-routes/parent/fox/1/optional/2')
+      .assert.containsText('pre', 'optional')
+
+      .click('a.optional-param-nested')
+      .assert.urlEquals('http://localhost:8080/nested-routes/parent/fox/1/optional/2/foxy')
+      .assert.containsText('.optional-param-nested-child pre', 'optional')
+
       .url('http://localhost:8080/nested-routes/parent/foo')
       .waitForElementVisible('#app', 1000)
       .assert.containsText('.view', 'Parent')


### PR DESCRIPTION
When navigating to a nested route, we do not discard the optional params for the parents to ensure that params are not lost.