### PR TITLE
Change `url="/"` to `url="index.html"`

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -87,7 +87,7 @@ For Node.js/Express, consider using [connect-history-api-fallback middleware](ht
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
           </conditions>
-          <action type="Rewrite" url="/" />
+          <action type="Rewrite" url="index.html" />
         </rule>
       </rules>
     </rewrite>


### PR DESCRIPTION
When `publicPath` is set, for some reason `url="/"` fails in the Rewrite.

`url="index.html"` works regardless of `publicPath` setting

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
