### PR TITLE
fix(create-matcher): "cannot assign to read only property path"

### DIFF
--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -54,8 +54,20 @@ export function createMatcher (
       }
 
       if (record) {
-        location.path = fillParams(record.path, location.params, `named route "${name}"`)
-        return _createRoute(record, location, redirectedFrom)
+        return _createRoute(
+          record,
+          Object.assign(
+            location,
+            {
+              path: fillParams(
+                record.path,
+                location.params,
+                `named route "${name}"`
+              )
+            }
+          ),
+          redirectedFrom
+        )
       }
     } else if (location.path) {
       location.params = {}


### PR DESCRIPTION
In create-matcher.js in match function location was marked as constant. That course as error described here (https://github.com/vuejs/vue-router/issues/1381)
