### PR TITLE
feat(transition): Using router push/replace instead of private history functions

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -146,9 +146,9 @@ export class History {
             // next('/') or next({ path: '/' }) -> redirect
             abort()
             if (typeof to === 'object' && to.replace) {
-              this.replace(to)
+              this.router.replace(to)
             } else {
-              this.push(to)
+              this.router.push(to)
             }
           } else {
             // confirm transition and pass on the value


### PR DESCRIPTION
I've found myself overriding the main Router to be able to control the `.back` method to prevent the user clicks on my app button a leaves the application. Check this example:

```javascript
class Router extends VueRouter {
  constructor (...args) {
    super(...args)

    this.counter = 0
  }

  push (location, ...args) {
    super.push(location, ...args)

    this.counter++
  }

  go (n) {
    if (this.counter + n < 0) {
      super.replace({ name: 'home.feed' })
    } else {
      super.go(n)
    }

    this.counter += n
  }
}
```

Thanks to this approach, product links can be shared without worring the back button that linked pages contain will destroy the application once pressed. (The same behaviour as Twitter PWA)

---

What I mean is the `beforeEach` guard is not respecting the overriden methods (push, replace, etc...), because it uses the `history` driver directly when it has to redirect to a route, instead of using the router instance.

This could be taken as a _Breaking Change_ for users like me that decided to wrap the router in their own classes, but I honestly think that this usage of the router is outside of the scope of the vue-router maintainers.

What do you all think?