### PR TITLE
docs: add descriptions for parseQuery / stringifyQuery

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -251,6 +251,8 @@ Since it's just a component, it works with `<transition>` and `<keep-alive>`. Wh
 - type: `Function`
 
   Provide custom query string parse / stringify functions. Overrides the default.
+  
+  Note that `stringifyQuery` is supposed to prepend a non-empty query with the question mark itself while `parseQuery` is passed the query string without the question mark in the beginning.
 
 ### fallback
 


### PR DESCRIPTION
This clears up what the implementor of these functions has to expect.

---

Stumbled across this while trying to use the [qs](https://www.npmjs.com/package/qs) package for `parseQuery` and `stringifyQuery` since I work with a PHP backend that relies on `foo[bar][baz]=qux` syntax with a strict RFC-3986 encoding.

Wording could probably be better since English ain't my primary language.

Greetings