### PR TITLE
Warn about root paths without a leading slash (fix #2550)

### DIFF
--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -18,11 +18,6 @@ export function createMatcher (
   router: VueRouter
 ): Matcher {
   const { pathList, pathMap, nameMap } = createRouteMap(routes)
-  const pathsMissingSlashes = pathList.filter(path => !!path && path.charAt(0) !== '/')
-
-  if (pathsMissingSlashes.length > 0) {
-    warn(false, `There is at least one root route without a leading slash in its path.`)
-  }
 
   function addRoutes (routes) {
     createRouteMap(routes, pathList, pathMap, nameMap)

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -18,6 +18,11 @@ export function createMatcher (
   router: VueRouter
 ): Matcher {
   const { pathList, pathMap, nameMap } = createRouteMap(routes)
+  const pathsMissingSlashes = pathList.filter(path => !!path && path.charAt(0) !== '/')
+
+  if (pathsMissingSlashes.length > 0) {
+    warn(false, `There is at least one root route without a leading slash in its path.`)
+  }
 
   function addRoutes (routes) {
     createRouteMap(routes, pathList, pathMap, nameMap)

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -37,10 +37,10 @@ export function createRouteMap (
   if (process.env.NODE_ENV === 'development') {
     // warn if routes do not include leading slashes
     const found = pathList
-      .find(path => path.charAt(0) !== '*' && path.charAt(0) !== '/')
+      .filter(path => path && path.charAt(0) !== '*' && path.charAt(0) !== '/')
 
-    if (found) {
-      warn(false, `Non-nested routes must include a leading slash character. Replace "${found}" with "/${found}".`)
+    if (found.length > 0) {
+      warn(false, `Non-nested routes must include a leading slash character. Replace "${found[0]}" with "/${found[0]}".`)
     }
   }
 

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -37,10 +37,15 @@ export function createRouteMap (
   if (process.env.NODE_ENV === 'development') {
     // warn if routes do not include leading slashes
     const found = pathList
+    // check for missing leading slash
       .filter(path => path && path.charAt(0) !== '*' && path.charAt(0) !== '/')
+    // split the path to get the root path part only
+      .map(path => path.split('/')[0])
+    // remove duplicates caused by split child paths
+      .filter((path, index, pathList) => pathList.indexOf(path) === index)
 
     if (found.length > 0) {
-      warn(false, `Non-nested routes must include a leading slash character. Replace "${found[0]}" with "/${found[0]}".`)
+      warn(false, `Non-nested routes must include a leading slash character. Fix the following routes: ${found.join('\n')}.`)
     }
   }
 

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -34,14 +34,14 @@ export function createRouteMap (
     }
   }
 
-  // warn if routes do not include leading slashes
-  const pathsMissingSlashes = pathList
-    .filter(path => !!path && path.charAt(0) !== '*' && path.charAt(0) !== '/')
-    .map(path => path.split('/')[0])
-    .filter((path, index, pathList) => pathList.indexOf(path) === index)
+  if (process.env.NODE_ENV === 'development') {
+    // warn if routes do not include leading slashes
+    const found = pathList
+      .find(path => path.charAt(0) !== '*' && path.charAt(0) !== '/')
 
-  if (pathsMissingSlashes.length > 0) {
-    warn(false, `The following routes require a leading slash in their paths: ${pathsMissingSlashes.join(', ')}`)
+    if (found) {
+      warn(false, `Non-nested routes must include a leading slash character. Replace "${found}" with "/${found}".`)
+    }
   }
 
   return {

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -39,13 +39,10 @@ export function createRouteMap (
     const found = pathList
     // check for missing leading slash
       .filter(path => path && path.charAt(0) !== '*' && path.charAt(0) !== '/')
-    // split the path to get the root path part only
-      .map(path => path.split('/')[0])
-    // remove duplicates caused by split child paths
-      .filter((path, index, pathList) => pathList.indexOf(path) === index)
 
     if (found.length > 0) {
-      warn(false, `Non-nested routes must include a leading slash character. Fix the following routes: ${found.join('\n')}.`)
+      const pathNames = found.map(path => `- ${path}`).join('\n')
+      warn(false, `Non-nested routes must include a leading slash character. Fix the following routes: \n${pathNames}`)
     }
   }
 

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -34,6 +34,16 @@ export function createRouteMap (
     }
   }
 
+  // warn if routes do not include leading slashes
+  const pathsMissingSlashes = pathList
+    .filter(path => !!path && path.charAt(0) !== '*' && path.charAt(0) !== '/')
+    .map(path => path.split('/')[0])
+    .filter((path, index, pathList) => pathList.indexOf(path) === index)
+
+  if (pathsMissingSlashes.length > 0) {
+    warn(false, `The following routes require a leading slash in their paths: ${pathsMissingSlashes.join(', ')}`)
+  }
+
   return {
     pathList,
     pathMap,

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -100,35 +100,21 @@ describe('Creating Route Map', function () {
   it('in development, warn if a path is missing a leading slash', function () {
     process.env.NODE_ENV = 'development'
     maps = createRouteMap([
-      { path: '/', name: 'home', component: Home },
-      { path: 'bar', name: 'bar', component: Bar },
-      { path: 'foo', name: 'foo', component: Foo,
-        children: [
-          { path: 'bar/:id', component: Bar }
-        ]
-      },
-      { path: '*', name: 'any', component: Baz }
+      { path: 'bar', name: 'bar', component: Bar }
     ])
     expect(console.warn).toHaveBeenCalledTimes(1)
-    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] The following routes require a leading slash in their paths: bar, foo')
+    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] Non-nested routes must include a leading slash character. Replace "bar" with "/bar".')
   })
 
-  it('in development, it has not logged a missing leading slash warning when all paths have slashes', function () {
+  it('in development, it does not log the missing leading slash when routes are valid', function () {
     process.env.NODE_ENV = 'development'
     maps = createRouteMap([
-      { path: '/', name: 'home', component: Home },
-      { path: '/bar', name: 'bar', component: Bar },
-      { path: '/foo', name: 'foo', component: Foo,
-        children: [
-          { path: 'bar/:id', component: Bar }
-        ]
-      },
-      { path: '*', name: 'any', component: Baz }
+      { path: '/bar', name: 'bar', component: Bar }
     ])
     expect(console.warn).not.toHaveBeenCalled()
   })
 
-  it('in production, it has not logged a missing leading slash warning', function () {
+  it('in production, it does not log the missing leading slash warning', function () {
     process.env.NODE_ENV = 'production'
     maps = createRouteMap([
       { path: '/', name: 'home', component: Home },

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -68,6 +68,7 @@ describe('Creating Route Map', function () {
     process.env.NODE_ENV = 'development'
     maps = createRouteMap(routes)
     expect(console.warn).toHaveBeenCalledTimes(1)
+    console.log(console.warn.calls.argsFor(1))
     expect(console.warn.calls.argsFor(0)[0]).toMatch('vue-router] Named Route \'bar\'')
   })
 

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -68,7 +68,6 @@ describe('Creating Route Map', function () {
     process.env.NODE_ENV = 'development'
     maps = createRouteMap(routes)
     expect(console.warn).toHaveBeenCalledTimes(1)
-    console.log(console.warn.calls.argsFor(1))
     expect(console.warn.calls.argsFor(0)[0]).toMatch('vue-router] Named Route \'bar\'')
   })
 

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -97,6 +97,48 @@ describe('Creating Route Map', function () {
     expect(console.warn.calls.argsFor(0)[0]).toMatch('vue-router] Duplicate param keys in route with path: "/foo/:id/bar/:id"')
   })
 
+  it('in development, warn if a path is missing a leading slash', function () {
+    process.env.NODE_ENV = 'development'
+    maps = createRouteMap([
+      { path: '/', name: 'home', component: Home },
+      { path: 'bar', name: 'bar', component: Bar },
+      { path: 'foo', name: 'foo', component: Foo,
+        children: [
+          { path: 'bar/:id', component: Bar }
+        ]
+      },
+      { path: '*', name: 'any', component: Baz }
+    ])
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] The following routes require a leading slash in their paths: bar, foo')
+  })
+
+  it('in development, it has not logged a missing leading slash warning when all paths have slashes', function () {
+    process.env.NODE_ENV = 'development'
+    maps = createRouteMap([
+      { path: '/', name: 'home', component: Home },
+      { path: '/bar', name: 'bar', component: Bar },
+      { path: '/foo', name: 'foo', component: Foo,
+        children: [
+          { path: 'bar/:id', component: Bar }
+        ]
+      },
+      { path: '*', name: 'any', component: Baz }
+    ])
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('in production, it has not logged a missing leading slash warning', function () {
+    process.env.NODE_ENV = 'production'
+    maps = createRouteMap([
+      { path: '/', name: 'home', component: Home },
+      { path: 'bar', name: 'bar', component: Bar },
+      { path: 'foo', name: 'foo', component: Foo },
+      { path: '*', name: 'any', component: Baz }
+    ])
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
   describe('path-to-regexp options', function () {
     const routes = [
       { path: '/foo', name: 'foo', component: Foo },

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -103,7 +103,7 @@ describe('Creating Route Map', function () {
       { path: 'bar', name: 'bar', component: Bar }
     ])
     expect(console.warn).toHaveBeenCalledTimes(1)
-    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] Non-nested routes must include a leading slash character. Fix the following routes: bar.')
+    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] Non-nested routes must include a leading slash character. Fix the following routes: \n- bar')
   })
 
   it('in development, it does not log the missing leading slash when routes are valid', function () {
@@ -117,10 +117,7 @@ describe('Creating Route Map', function () {
   it('in production, it does not log the missing leading slash warning', function () {
     process.env.NODE_ENV = 'production'
     maps = createRouteMap([
-      { path: '/', name: 'home', component: Home },
-      { path: 'bar', name: 'bar', component: Bar },
-      { path: 'foo', name: 'foo', component: Foo },
-      { path: '*', name: 'any', component: Baz }
+      { path: 'bar', name: 'bar', component: Bar }
     ])
     expect(console.warn).not.toHaveBeenCalled()
   })

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -103,7 +103,7 @@ describe('Creating Route Map', function () {
       { path: 'bar', name: 'bar', component: Bar }
     ])
     expect(console.warn).toHaveBeenCalledTimes(1)
-    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] Non-nested routes must include a leading slash character. Replace "bar" with "/bar".')
+    expect(console.warn.calls.argsFor(0)[0]).toEqual('[vue-router] Non-nested routes must include a leading slash character. Fix the following routes: bar.')
   })
 
   it('in development, it does not log the missing leading slash when routes are valid', function () {


### PR DESCRIPTION
close #2550

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This PR creates the following warning message when a root route exists without a leading slash:
<img width="583" alt="screen shot 2019-01-22 at 3 12 15 am" src="https://user-images.githubusercontent.com/13800170/51506192-b2785600-1df3-11e9-8ef0-7607ac68aa2b.png">

This facilitates the debugging process as the current behavior does not generate any warnings or errors.