### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -505,4 +505,4 @@ These properties are injected into every child component by passing the router i
 - **beforeRouteUpdate**
 - **beforeRouteLeave**
 
-  See [In Component Guards](../guide/advanced/navigation-guards.md#incomponent-guards).
+  See [In Component Guards](../guide/advanced/navigation-guards.md#in-component-guards).


### PR DESCRIPTION
At the bottom of the API Reference page, the "In Component Guards" link in the [Component Enabled Options section](https://router.vuejs.org/api/#component-enabled-options) wasn't pointing at the correct header.