### PR TITLE
fix(router): prevent memory leaks by removing app references from $router.apps once app destroyed (Fixes #2639)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export default class VueRouter {
 
     // main app already initialized.
     if (this.app) {
-     app.$once('hook:destroyed', () {
+     app.$once('hook:destroyed', () => {
        // Clean out app from this.apps array once destroyed
        const index = this.apps.indexOf(app)
        if (index > -1) this.apps.splice(index, 1)

--- a/src/index.js
+++ b/src/index.js
@@ -89,13 +89,16 @@ export default class VueRouter {
 
     this.apps.push(app)
 
+    // Clean out app from this.apps array once destroyed
+    app.$once('hook:destroyed', () => {
+      const index = this.apps.indexOf(app)
+      if (index > -1) this.apps.splice(index, 1)
+      // Ensure we still have a main app
+      if (this.apps[0]) this.app = this.apps[0]
+    })
+
     // main app already initialized.
     if (this.app) {
-      app.$once('hook:destroyed', () => {
-        // Clean out app from this.apps array once destroyed
-        const index = this.apps.indexOf(app)
-        if (index > -1) this.apps.splice(index, 1)
-      })
       return
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,12 @@ export default class VueRouter {
 
     // main app already initialized.
     if (this.app) {
-      return
+     app.$once('hook:destroyed', () {
+       // Clean out app from this.apps array once destroyed
+       const index = this.apps.indexOf(app)
+       if (index > -1) this.apps.splice(index, 1)
+     })
+     return
     }
 
     this.app = app

--- a/src/index.js
+++ b/src/index.js
@@ -91,12 +91,12 @@ export default class VueRouter {
 
     // main app already initialized.
     if (this.app) {
-     app.$once('hook:destroyed', () => {
-       // Clean out app from this.apps array once destroyed
-       const index = this.apps.indexOf(app)
-       if (index > -1) this.apps.splice(index, 1)
-     })
-     return
+      app.$once('hook:destroyed', () => {
+        // Clean out app from this.apps array once destroyed
+        const index = this.apps.indexOf(app)
+        if (index > -1) this.apps.splice(index, 1)
+      })
+      return
     }
 
     this.app = app

--- a/src/index.js
+++ b/src/index.js
@@ -89,16 +89,22 @@ export default class VueRouter {
 
     this.apps.push(app)
 
-    // Clean out app from this.apps array once destroyed
+    // set up app destroyed handler
     app.$once('hook:destroyed', () => {
+      // clean out app from this.apps array once destroyed
       const index = this.apps.indexOf(app)
       if (index > -1) this.apps.splice(index, 1)
-      // Ensure we still have a main app
-      if (this.apps[0]) this.app = this.apps[0]
+      // ensure we still have a main app, unless this is the last app left
+      if (this.apps.length > 0) this.app = this.apps[0]
     })
 
-    // main app already initialized.
+    // main app previously initialized
     if (this.app) {
+      if (this.app !== this.apps[0]) {
+        // main app had been destroyed, so replace it with this new app
+        this.app = this.apps[0]
+      }
+      // return as we don't need to set up new history listener
       return
     }
 

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -201,17 +201,19 @@ describe('router app destroy handling', () => {
 
   it('should remove 2nd destroyed app from this.apps', () => {
     app2.$destroy()
+    expect(app1.$router).toBeDefined()
+    expect(app1.$router.app).toBeDefined()
     expect(app1.$router.app).toBe(app1)
     expect(app1.$router.apps.length).toBe(2)
-    expect(app1.$router.app[0]).toBe(app1)
-    expect(app1.$router.app[1]).toBe(app3)
+    expect(app1.$router.apps[0]).toBe(app1)
+    expect(app1.$router.apps[1]).toBe(app3)
   })
 
   it('should remove 1st destroyed app from this.apps and replace this.app', () => {
     app1.$destroy()
     expect(app3.$router.app).toBe(app3)
     expect(app3.$router.apps.length).toBe(1)
-    expect(app3.$router.app[0]).toBe(app3)
+    expect(app3.$router.apps[0]).toBe(app3)
   })
 
   it('should remove last destroyed app from this.apps', () => {
@@ -227,6 +229,6 @@ describe('router app destroy handling', () => {
     })
     expect(app4.$router.app).toBe(app4)
     expect(app4.$router.apps.length).toBe(1)
-    expect(app4.$router.app[0]).toBe(app4)
+    expect(app4.$router.apps[0]).toBe(app4)
   })
 })

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -156,29 +156,33 @@ describe('router app destroy handling', () => {
       ]
     })
 
-    const options = {
-      router,
-      render(h) { return h('div') }
-    }
-
     expect(router.apps.length).toBe(0)
     expect(router.app).toBe(null)
 
     // Add main app
-    const app1 = new Vue(options)
+    const app1 = new Vue({
+      router,
+      render (h) { return h('div') }
+    })
     expect(router.app).toBe(app1)
     expect(router.apps.length).toBe(1)
     expect(router.app[0]).toBe(app1)
 
     // Add 2nd app
-    const app2 = new Vue(options)
+    const app2 = new Vue({
+      router,
+      render (h) { return h('div') }
+    })
     expect(router.app).toBe(app1)
     expect(router.apps.length).toBe(2)
     expect(router.app[0]).toBe(app1)
     expect(router.app[1]).toBe(app2)
 
     // Add 3rd app
-    const app3 = new Vue(options)
+    const app3 = new Vue({
+      router,
+      render (h) { return h('div') }
+    })
     expect(router.app).toBe(app1)
     expect(router.apps.length).toBe(3)
     expect(router.app[0]).toBe(app1)
@@ -186,25 +190,28 @@ describe('router app destroy handling', () => {
     expect(router.app[2]).toBe(app3)
 
     // Destroy second app
-    app2.destroy()
+    app2.$destroy()
     expect(router.app).toBe(app1)
     expect(router.apps.length).toBe(2)
     expect(router.app[0]).toBe(app1)
     expect(router.app[1]).toBe(app3)
 
     // Destroy 1st app
-    app1.destroy()
+    app1.$destroy()
     expect(router.app).toBe(app3)
     expect(router.apps.length).toBe(1)
     expect(router.app[0]).toBe(app3)
 
     // Destroy 3rd app
-    app3.destroy()
+    app3.$destroy()
     expect(router.app).toBe(app3)
     expect(router.apps.length).toBe(0)
 
     // Add 4th app (should be the only app)
-    const app4 = new Vue(options)
+    const app4 = new Vue({
+      router,
+      render (h) { return h('div') }
+    })
     expect(router.app).toBe(app4)
     expect(router.apps.length).toBe(1)
     expect(router.app[0]).toBe(app4)

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -148,74 +148,87 @@ describe('router.push/replace callbacks', () => {
 })
 
 describe('router app destroy handling', () => {
-  it('should remove destroyed apps from this.apps', () => {
-    Vue.use(Router)
+  Vue.use(Router)
 
-    const router = new Router({
-      mode: 'abstract',
-      routes: [
-        { path: '/', component: { name: 'A' }}
-      ]
-    })
+  const router = new Router({
+    mode: 'abstract',
+    routes: [
+      { path: '/', component: { name: 'A' }}
+    ]
+  })
 
-    expect(router.apps.length).toBe(0)
-    expect(router.app).toBe(null)
+  // Add main app
+  const app1 = new Vue({
+    router,
+    render (h) { return h('div') }
+  })
 
-    // Add main app
-    const app1 = new Vue({
-      router,
-      render (h) { return h('div') }
-    })
-    expect(router.app).toBe(app1)
-    expect(router.apps.length).toBe(1)
-    expect(router.app[0]).toBe(app1)
+  // Add 2nd app
+  const app2 = new Vue({
+    router,
+    render (h) { return h('div') }
+  })
 
-    // Add 2nd app
-    const app2 = new Vue({
-      router,
-      render (h) { return h('div') }
-    })
-    expect(router.app).toBe(app1)
-    expect(router.apps.length).toBe(2)
-    expect(router.app[0]).toBe(app1)
-    expect(router.app[1]).toBe(app2)
+  // Add 3rd app
+  const app3 = new Vue({
+    router,
+    render (h) { return h('div') }
+  })
 
-    // Add 3rd app
-    const app3 = new Vue({
-      router,
-      render (h) { return h('div') }
-    })
-    expect(router.app).toBe(app1)
-    expect(router.apps.length).toBe(3)
-    expect(router.app[0]).toBe(app1)
-    expect(router.app[1]).toBe(app2)
-    expect(router.app[2]).toBe(app3)
+  it('router and apps should be defined', async () => {
+    expect(router).toBeDefined()
+    expect(router).toBeInstanceOf(Router)
+    expect(app1).toBeDefined()
+    expect(app1).toBeInstanceOf(Vue)
+    expect(app2).toBeDefined()
+    expect(app2).toBeInstanceOf(Vue)
+    expect(app3).toBeDefined()
+    expect(app3).toBeInstanceOf(Vue)
+    expect(app1.$router.apps).toBe(app2.$router.apps)
+    expect(app2.$router.apps).toBe(app3.$router.apps)
+  })
 
-    // Destroy second app
+  it('should have 3 registered apps', async () => {
+    expect(app1.$router).toBeDefined()
+    expect(app1.$router.app).toBe(app1)
+    expect(app1.$router.apps.length).toBe(3)
+    expect(app1.$router.apps[0]).toBe(app1)
+    expect(app1.$router.apps[1]).toBe(app2)
+    expect(app1.$router.apps[2]).toBe(app3)
+  })
+
+  it('should remove 2nd destroyed app from this.apps', async () => {
     app2.$destroy()
-    expect(router.app).toBe(app1)
-    expect(router.apps.length).toBe(2)
-    expect(router.app[0]).toBe(app1)
-    expect(router.app[1]).toBe(app3)
+    await Vue.nextTick()
+    expect(app1.$router.app).toBe(app1)
+    expect(app1.$router.apps.length).toBe(2)
+    expect(app1.$router.app[0]).toBe(app1)
+    expect(app1.$router.app[1]).toBe(app3)
+  })
 
-    // Destroy 1st app
+  it('should remove 1st destroyed app from this.apps and replace this.app', async () => {
     app1.$destroy()
-    expect(router.app).toBe(app3)
-    expect(router.apps.length).toBe(1)
-    expect(router.app[0]).toBe(app3)
+    await Vue.nextTick()
+    expect(app3.$router.app).toBe(app3)
+    expect(app3.$router.apps.length).toBe(1)
+    expect(app3.$router.app[0]).toBe(app3)
+  })
 
-    // Destroy 3rd app
+  it('should remove last destroyed app from this.apps', async () => {
     app3.$destroy()
-    expect(router.app).toBe(app3)
-    expect(router.apps.length).toBe(0)
+    await Vue.nextTick()
+    expect(app3.$router.app).toBe(app3)
+    expect(app3.$router.apps.length).toBe(0)
+  })
 
-    // Add 4th app (should be the only app)
+  it('should replace app with new app', async () => {
     const app4 = new Vue({
       router,
       render (h) { return h('div') }
     })
-    expect(router.app).toBe(app4)
-    expect(router.apps.length).toBe(1)
-    expect(router.app[0]).toBe(app4)
+    await Vue.nextTick()
+    expect(app4.$router.app).toBe(app4)
+    expect(app4.$router.apps.length).toBe(1)
+    expect(app4.$router.app[0]).toBe(app4)
   })
 })

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -149,6 +149,8 @@ describe('router.push/replace callbacks', () => {
 
 describe('router app destroy handling', () => {
   it('should remove destroyed apps from this.apps', () => {
+    Vue.use(Router)
+
     const router = new Router({
       mode: 'abstract',
       routes: [

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -177,15 +177,17 @@ describe('router app destroy handling', () => {
 
   it('router and apps should be defined', () => {
     expect(router).toBeDefined()
-    expect(router).toBeInstanceOf(Router)
+    expect(router istanceof Router).toBe(true)
     expect(app1).toBeDefined()
-    expect(app1).toBeInstanceOf(Vue)
+    expect(app1 instanceof Vue).toBe(true)
     expect(app2).toBeDefined()
-    expect(app2).toBeInstanceOf(Vue)
+    expect(app2 instanceof Vue).toBe(true)
     expect(app3).toBeDefined()
-    expect(app3).toBeInstanceOf(Vue)
+    expect(app3 instanceof Vue).toBe(true)
     expect(app1.$router.apps).toBe(app2.$router.apps)
     expect(app2.$router.apps).toBe(app3.$router.apps)
+    expect(app1.$router.app).toBe(app2.$router.app)
+    expect(app2.$router.app).toBe(app3.$router.app)
   })
 
   it('should have 3 registered apps', () => {

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -175,7 +175,7 @@ describe('router app destroy handling', () => {
     render (h) { return h('div') }
   })
 
-  it('router and apps should be defined', async () => {
+  it('router and apps should be defined', () => {
     expect(router).toBeDefined()
     expect(router).toBeInstanceOf(Router)
     expect(app1).toBeDefined()
@@ -188,7 +188,7 @@ describe('router app destroy handling', () => {
     expect(app2.$router.apps).toBe(app3.$router.apps)
   })
 
-  it('should have 3 registered apps', async () => {
+  it('should have 3 registered apps', () => {
     expect(app1.$router).toBeDefined()
     expect(app1.$router.app).toBe(app1)
     expect(app1.$router.apps.length).toBe(3)
@@ -197,36 +197,32 @@ describe('router app destroy handling', () => {
     expect(app1.$router.apps[2]).toBe(app3)
   })
 
-  it('should remove 2nd destroyed app from this.apps', async () => {
+  it('should remove 2nd destroyed app from this.apps', () => {
     app2.$destroy()
-    await Vue.nextTick()
     expect(app1.$router.app).toBe(app1)
     expect(app1.$router.apps.length).toBe(2)
     expect(app1.$router.app[0]).toBe(app1)
     expect(app1.$router.app[1]).toBe(app3)
   })
 
-  it('should remove 1st destroyed app from this.apps and replace this.app', async () => {
+  it('should remove 1st destroyed app from this.apps and replace this.app', () => {
     app1.$destroy()
-    await Vue.nextTick()
     expect(app3.$router.app).toBe(app3)
     expect(app3.$router.apps.length).toBe(1)
     expect(app3.$router.app[0]).toBe(app3)
   })
 
-  it('should remove last destroyed app from this.apps', async () => {
+  it('should remove last destroyed app from this.apps', () => {
     app3.$destroy()
-    await Vue.nextTick()
     expect(app3.$router.app).toBe(app3)
     expect(app3.$router.apps.length).toBe(0)
   })
 
-  it('should replace app with new app', async () => {
+  it('should replace app with new app', () => {
     const app4 = new Vue({
       router,
       render (h) { return h('div') }
     })
-    await Vue.nextTick()
     expect(app4.$router.app).toBe(app4)
     expect(app4.$router.apps.length).toBe(1)
     expect(app4.$router.app[0]).toBe(app4)

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -177,7 +177,7 @@ describe('router app destroy handling', () => {
 
   it('router and apps should be defined', () => {
     expect(router).toBeDefined()
-    expect(router istanceof Router).toBe(true)
+    expect(router instanceof Router).toBe(true)
     expect(app1).toBeDefined()
     expect(app1 instanceof Vue).toBe(true)
     expect(app2).toBeDefined()

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -1,4 +1,5 @@
 import Router from '../../../src/index'
+import Vue from 'vue'
 
 describe('router.onReady', () => {
   it('should work', done => {
@@ -143,5 +144,69 @@ describe('router.push/replace callbacks', () => {
       expect(spy2).toHaveBeenCalled()
       done()
     })
+  })
+})
+
+describe('router app destroy handling', () => {
+  it('should remove destroyed apps from this.apps', () => {
+    const router = new Router({
+      mode: 'abstract',
+      routes: [
+        { path: '/', component: { name: 'A' }}
+      ]
+    })
+
+    const options = {
+      router,
+      render(h) { return h('div') }
+    }
+
+    expect(router.apps.length).toBe(0)
+    expect(router.app).toBe(null)
+
+    // Add main app
+    const app1 = new Vue(options)
+    expect(router.app).toBe(app1)
+    expect(router.apps.length).toBe(1)
+    expect(router.app[0]).toBe(app1)
+
+    // Add 2nd app
+    const app2 = new Vue(options)
+    expect(router.app).toBe(app1)
+    expect(router.apps.length).toBe(2)
+    expect(router.app[0]).toBe(app1)
+    expect(router.app[1]).toBe(app2)
+
+    // Add 3rd app
+    const app3 = new Vue(options)
+    expect(router.app).toBe(app1)
+    expect(router.apps.length).toBe(3)
+    expect(router.app[0]).toBe(app1)
+    expect(router.app[1]).toBe(app2)
+    expect(router.app[2]).toBe(app3)
+
+    // Destroy second app
+    app2.destroy()
+    expect(router.app).toBe(app1)
+    expect(router.apps.length).toBe(2)
+    expect(router.app[0]).toBe(app1)
+    expect(router.app[1]).toBe(app3)
+
+    // Destroy 1st app
+    app1.destroy()
+    expect(router.app).toBe(app3)
+    expect(router.apps.length).toBe(1)
+    expect(router.app[0]).toBe(app3)
+
+    // Destroy 3rd app
+    app3.destroy()
+    expect(router.app).toBe(app3)
+    expect(router.apps.length).toBe(0)
+
+    // Add 4th app (should be the only app)
+    const app4 = new Vue(options)
+    expect(router.app).toBe(app4)
+    expect(router.apps.length).toBe(1)
+    expect(router.app[0]).toBe(app4)
   })
 })


### PR DESCRIPTION
Prevent memory leaks by removing app(s) from `$router.apps` array once app has been destroyed.

Fixes #2639

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
