### PR TITLE
Make the build reproducible

### DIFF
--- a/build/configs.js
+++ b/build/configs.js
@@ -5,10 +5,11 @@ const cjs = require('rollup-plugin-commonjs')
 const node = require('rollup-plugin-node-resolve')
 const replace = require('rollup-plugin-replace')
 const version = process.env.VERSION || require('../package.json').version
+const now = new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime());
 const banner =
 `/*!
   * vue-router v${version}
-  * (c) ${new Date().getFullYear()} Evan You
+  * (c) ${now.getFullYear()} Evan You
   * @license MIT
   */`
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, we noticed that vue-router could not be built reproducibly.

This is due to it embedding the current build year into the file headers. This has been replaced with using [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) where available. This was originally filed in Debian as [#924378](https://bugs.debian.org/924378).