### PR TITLE
docs(zh): add more details to resolution flow

### DIFF
--- a/docs/zh/guide/advanced/navigation-guards.md
+++ b/docs/zh/guide/advanced/navigation-guards.md
@@ -153,4 +153,4 @@ beforeRouteLeave (to, from , next) {
 9. 导航被确认。
 10. 调用全局的 `afterEach` 钩子。
 11. 触发 DOM 更新。
-12. 用创建好的实例调用 `beforeRouteEnter` 守卫中传给 `next` 的回调函数。
+12. 调用 `beforeRouteEnter` 守卫中传给 `next` 的回调函数，被激活的组件实例会作为回调函数的参数传入

--- a/docs/zh/guide/advanced/navigation-guards.md
+++ b/docs/zh/guide/advanced/navigation-guards.md
@@ -153,4 +153,4 @@ beforeRouteLeave (to, from , next) {
 9. 导航被确认。
 10. 调用全局的 `afterEach` 钩子。
 11. 触发 DOM 更新。
-12. 调用 `beforeRouteEnter` 守卫中传给 `next` 的回调函数，被激活的组件实例会作为回调函数的参数传入
+12. 调用 `beforeRouteEnter` 守卫中传给 `next` 的回调函数，创建好的组件实例会作为回调函数的参数传入。


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
原文是“用创建好的实例调用 `beforeRouteEnter` 守卫中传给 `next` 的回调函数”，用创建好的什么实例？路由实例？

英文为“Call callbacks passed to `next` in `beforeRouteEnter` guards with instantiated instances”，我认为 call...with 应该是使用其作为调用 callback 参数的意思，而不是用它来调用 callback