### PR TITLE
test: split navigation guards test code into two steps

### DIFF
--- a/test/e2e/specs/navigation-guards.js
+++ b/test/e2e/specs/navigation-guards.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'navigation guards step one': function (browser) {
+  'navigation guards with alerts': function (browser) {
     browser
       .url('http://localhost:8080/navigation-guards/')
       .waitForElementVisible('#app', 1000)
@@ -7,9 +7,7 @@ module.exports = {
       .assert.containsText('.view', 'home')
 
     // alert commands not available in phantom
-    if (process.env.PHANTOMJS) {
-      return
-    }
+    if (process.env.PHANTOMJS) return
 
     browser
       .click('li:nth-child(2) a')
@@ -64,16 +62,8 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/navigation-guards/foo')
       .assert.containsText('.view', 'foo')
 
-      .click('li:nth-child(4) a')
-      .assert.urlEquals('http://localhost:8080/navigation-guards/baz')
-      .assert.containsText('.view', 'baz (not saved)')
-      .click('button')
-      .assert.containsText('.view', 'baz (saved)')
-      .click('li:nth-child(1) a')
-      .assert.urlEquals('http://localhost:8080/navigation-guards/')
-      .assert.containsText('.view', 'home')
-
-      // test initial visit
+    // test initial visit
+    browser
       .url('http://localhost:8080/navigation-guards/foo')
       .dismissAlert()
       .waitFor(100)
@@ -102,10 +92,20 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/navigation-guards/bar')
       .assert.containsText('.view', 'bar')
   },
-  'navigation guards step two': function (browser) {
+  'navigation guards': function (browser) {
     browser
       // back to home
       .url('http://localhost:8080/navigation-guards/')
+      .waitForElementVisible('#app', 1000)
+      .assert.containsText('.view', 'home')
+
+      .click('li:nth-child(4) a')
+      .assert.urlEquals('http://localhost:8080/navigation-guards/baz')
+      .assert.containsText('.view', 'baz (not saved)')
+      .click('button')
+      .assert.containsText('.view', 'baz (saved)')
+      .click('li:nth-child(1) a')
+      .assert.urlEquals('http://localhost:8080/navigation-guards/')
       .assert.containsText('.view', 'home')
 
       // in-component guard

--- a/test/e2e/specs/navigation-guards.js
+++ b/test/e2e/specs/navigation-guards.js
@@ -1,16 +1,17 @@
 module.exports = {
-  'navigation guards': function (browser) {
-    // alert commands not available in phantom
-    if (process.env.PHANTOMJS) {
-      return
-    }
-
+  'navigation guards step one': function (browser) {
     browser
       .url('http://localhost:8080/navigation-guards/')
       .waitForElementVisible('#app', 1000)
       .assert.count('li a', 8)
       .assert.containsText('.view', 'home')
 
+    // alert commands not available in phantom
+    if (process.env.PHANTOMJS) {
+      return
+    }
+
+    browser
       .click('li:nth-child(2) a')
       .dismissAlert()
       .waitFor(100)
@@ -100,16 +101,22 @@ module.exports = {
       .acceptAlert()
       .assert.urlEquals('http://localhost:8080/navigation-guards/bar')
       .assert.containsText('.view', 'bar')
+  },
+  'navigation guards step two': function (browser) {
+    browser
+      // back to home
+      .url('http://localhost:8080/navigation-guards/')
+      .assert.containsText('.view', 'home')
 
-    // in-component guard
+      // in-component guard
       .click('li:nth-child(5) a')
-      .assert.urlEquals('http://localhost:8080/navigation-guards/bar')
-      .assert.containsText('.view', 'bar')
+      .assert.urlEquals('http://localhost:8080/navigation-guards/')
+      .assert.containsText('.view', 'home')
       .waitFor(300)
       .assert.urlEquals('http://localhost:8080/navigation-guards/qux')
       .assert.containsText('.view', 'Qux')
 
-    // async component + in-component guard
+      // async component + in-component guard
       .click('li:nth-child(1) a')
       .assert.urlEquals('http://localhost:8080/navigation-guards/')
       .assert.containsText('.view', 'home')
@@ -120,7 +127,7 @@ module.exports = {
       .assert.urlEquals('http://localhost:8080/navigation-guards/qux-async')
       .assert.containsText('.view', 'Qux')
 
-    // beforeRouteUpdate
+      // beforeRouteUpdate
       .click('li:nth-child(7) a')
       .assert.urlEquals('http://localhost:8080/navigation-guards/quux/1')
       .assert.containsText('.view', 'id:1 prevId:0')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Not all the test code uses `confirm` in the file [navigation-guards](https://github.com/vuejs/vue-router/blob/dev/test/e2e/specs/navigation-guards.js). Split it out, and make it can be executed under any condition.
