### PR TITLE
Support for apps loaded from Windows file shares

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -9,7 +9,10 @@ const positionStore = Object.create(null)
 export function setupScroll () {
   // Fix for #1585 for Firefox
   // Fix for #2195 Add optional third attribute to workaround a bug in safari https://bugs.webkit.org/show_bug.cgi?id=182678
-  window.history.replaceState({ key: getStateKey() }, '', window.location.href.replace(window.location.origin, ''))
+  // Fix for #2774 Support for apps loaded from Windows file shares not mapped to network drives
+  const protocolAndPath = window.location.protocol + '//' + window.location.host
+  const absolutePath = window.location.href.replace(protocolAndPath, '')
+  window.history.replaceState({ key: getStateKey() }, '', absolutePath)
   window.addEventListener('popstate', e => {
     saveScrollPosition()
     if (e.state && e.state.key) {


### PR DESCRIPTION
When loading an application from a Windows file share (not mapped to a network letter), Chrome will throw an error (`cannot be created in a document with origin 'null'`) when `replaceState` is called. This happens because while `protocol` is `file:` and `host` is `vboxsvr` the `origin` is `file://` as opposed to `file://vboxsvr`. This means the absolute path is not created correctly.

Only Windows shares that are not mapped to a drive letter are affected. If a drive letter is mapped then while origin will still be `file://`, pathname will include the information instead (e.g. `/Z:/dist/index.html`)

This code removes the reliance on the origin attribute and calculates the absolute path from `protocol` and `host`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
