### PR TITLE
Add Location definition under router-link section in API

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -61,6 +61,20 @@ In this case the `<a>` will be the actual link (and will get the correct `href`)
   <router-link :to="{ path: 'register', query: { plan: 'private' }}">Register</router-link>
   ```
 
+  Type declaration for `Location`:
+
+  ```js
+  declare type Location = {
+    name?: string; // for named routes
+    path?: string;
+    hash?: string; // Must start with a #
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    append?: boolean;
+    replace?: boolean;
+  }
+  ```
+
 ### replace
 
 - type: `boolean`

--- a/docs/fr/api/README.md
+++ b/docs/fr/api/README.md
@@ -61,6 +61,20 @@ Dans ce cas, `<a>` sera le lien actuel (et récupèrera le bon `href`), mais la 
   <router-link :to="{ path: 'register', query: { plan: 'private' }}">S'enregistrer</router-link>
   ```
 
+  Déclaration de type pour `Location`:
+
+  ```js
+  declare type Location = {
+    name?: string; // pour les routes nommées
+    path?: string;
+    hash?: string; // Doit commencer par un #
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    append?: boolean;
+    replace?: boolean;
+  }
+  ```
+
 
 ### replace
 

--- a/docs/ja/api/README.md
+++ b/docs/ja/api/README.md
@@ -59,6 +59,20 @@ sidebar: auto
   <router-link :to="{ path: 'register', query: { plan: 'private' }}">Register</router-link>
   ```
 
+  `Location` の型宣言:
+
+  ```js
+  declare type Location = {
+    name?: string; // 名前付きルート用
+    path?: string;
+    hash?: string; // ＃で始まらなければなりません
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    append?: boolean;
+    replace?: boolean;
+  }
+  ```
+
 ### replace
 
   - 型: `boolean`

--- a/docs/kr/api/README.md
+++ b/docs/kr/api/README.md
@@ -48,6 +48,20 @@ sidebar: auto
   <router-link :to="{ path: 'register', query: { plan: 'private' }}">Register</router-link>
   ```
 
+  Type declaration for `Location`:
+
+  ```js
+  declare type Location = {
+    name?: string; // for named routes
+    path?: string;
+    hash?: string; // Must start with a #
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    append?: boolean;
+    replace?: boolean;
+  }
+  ```
+
 ### replace
 
   - 자료형: `boolean`

--- a/docs/ru/api/README.md
+++ b/docs/ru/api/README.md
@@ -61,6 +61,20 @@ sidebar: auto
   <router-link :to="{ path: 'register', query: { plan: 'private' }}">Register</router-link>
   ```
 
+  Декларация типа для `Location`:
+
+  ```js
+  declare type Location = {
+    name?: string; // для именованных маршрутов
+    path?: string;
+    hash?: string; // Должен начинаться с #
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    append?: boolean;
+    replace?: boolean;
+  }
+  ```
+
 ### replace
 
 - тип: `boolean`

--- a/docs/zh/api/README.md
+++ b/docs/zh/api/README.md
@@ -62,6 +62,20 @@ sidebar: auto
   <router-link :to="{ path: 'register', query: { plan: 'private' }}">Register</router-link>
   ```
 
+  `Location` 的类型定义:
+
+  ```js
+  declare type Location = {
+    name?: string; // 命名路由
+    path?: string;
+    hash?: string; // 必须以＃开头
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    append?: boolean;
+    replace?: boolean;
+  }
+  ```
+
 ### replace
 
 - 类型: `boolean`


### PR DESCRIPTION
Related to my doh moment #2778. Adding information about the Location Object to router-link as it is missing from the docs.

The translation for kr needs to be done and the translation of "Must start with a #" needs to be checked for the other translations as it was done with Google translate.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
