### PR TITLE
False positive incorrect type. What can be passed as param on `this.$router.push` unnecessarily limited to string

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -109,7 +109,7 @@ export interface Location {
   path?: string;
   hash?: string;
   query?: Dictionary<string | (string | null)[] | null | undefined>;
-  params?: Dictionary<string>;
+  params?: Dictionary<any>;
   append?: boolean;
   replace?: boolean;
 }


### PR DESCRIPTION
**BEFORE:**
  The implementation assumes that only a sting can be passed as a prop
```
this.$router.push({
        name: 'route',
        params: {
            propName: 'a string', // <= OK
            propNameNumber: 5, // <= WRONG
            propNameArray: [5, 'string', {id: 4, color: MyEnum.RED], // <= WRONG
        }
});
```

Actually Vue.js does allow for types that the offending .d.ts disallows.

**AFTER:**
  False positive cases accepted as correct.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
