### PR TITLE
chore(test): improve e2e test runner warning

### DIFF
--- a/test/e2e/runner.js
+++ b/test/e2e/runner.js
@@ -39,7 +39,6 @@ const NW_CONFIG = isLocal
 // add a configuration by default if not provided
 // add a configuration by default if not provided
 if (args.indexOf('-c') < 0) {
-  args.push('-c', NW_CONFIG)
   // check if multiple envs are provided. The way Nightwatch works
   // requires to explicitely provide the conf
   const envs = args[args.indexOf('-e') + 1]
@@ -51,6 +50,7 @@ if (args.indexOf('-c') < 0) {
     )
     process.exit(1)
   }
+  args.push('-c', NW_CONFIG)
 } else if (isLocal) {
   const conf = args[args.indexOf('-c') + 1]
   if (resolve('.', conf) !== NW_CONFIG) {


### PR DESCRIPTION
Avoiding warning `-c ${NW_CONFIG}` twice.<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
