### PR TITLE
test: fix running e2e in Firefox

### DIFF
--- a/test/e2e/nightwatch.config.js
+++ b/test/e2e/nightwatch.config.js
@@ -32,10 +32,7 @@ module.exports = {
       },
       desiredCapabilities: {
         browserName: 'chrome',
-        acceptSslCerts: true,
-        chromeOptions: {
-          args: ['window-size=1280,800', 'headless']
-        }
+        acceptSslCerts: true
       }
     },
 
@@ -44,7 +41,7 @@ module.exports = {
         browserName: 'chrome',
         acceptSslCerts: true,
         chromeOptions: {
-          args: ['window-size=1280,800']
+          args: ['window-size=1280,800', 'headless']
         }
       }
     },

--- a/test/e2e/runner.js
+++ b/test/e2e/runner.js
@@ -32,12 +32,13 @@ const server =
 const isLocal = args.indexOf('--local') > -1
 
 const DEFAULT_CONFIG = './nightwatch.json'
+const DEFAULT = 'default'
+const NW_ENV = 'chrome'
 const NW_CONFIG = isLocal
   ? resolve(__dirname, './nightwatch.browserstack.js')
   : resolve(__dirname, './nightwatch.config.js')
 
-// add a configuration by default if not provided
-// add a configuration by default if not provided
+// check configuration
 if (args.indexOf('-c') < 0) {
   // check if multiple envs are provided. The way Nightwatch works
   // requires to explicitely provide the conf
@@ -50,7 +51,6 @@ if (args.indexOf('-c') < 0) {
     )
     process.exit(1)
   }
-  args.push('-c', NW_CONFIG)
 } else if (isLocal) {
   const conf = args[args.indexOf('-c') + 1]
   if (resolve('.', conf) !== NW_CONFIG) {
@@ -66,6 +66,10 @@ function adaptArgv (argv) {
 
   if (argv.c === DEFAULT_CONFIG && argv.config === DEFAULT_CONFIG) {
     argv.config = argv.c = NW_CONFIG
+  }
+
+  if (argv.e === DEFAULT && argv.env === DEFAULT) {
+    argv.env = argv.e = NW_ENV
   }
   // Nightwatch does not accept an array with one element
   if (argv.test.length === 1) argv.test = argv.test[0]


### PR DESCRIPTION
1. make `npm run test:e2e:ff` working as expected, [related info](https://github.com/nightwatchjs/nightwatch/issues/2128).
2. add `-e chrome` as default env to nightwatch (`npm run test:e2e` with chromeOptions config applied).
3. remove useless code and comments.<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
