### PR TITLE
feat: return a promise with push and replace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,8 +153,8 @@ export default class VueRouter {
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     // $flow-disable-line
     if (!onComplete && !onAbort && typeof Promise !== 'undefined') {
-      return new Promise(resolve => {
-        this.history.push(location, resolve)
+      return new Promise((resolve, reject) => {
+        this.history.push(location, resolve, reject)
       })
     } else {
       this.history.push(location, onComplete, onAbort)
@@ -164,8 +164,8 @@ export default class VueRouter {
   replace (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     // $flow-disable-line
     if (!onComplete && !onAbort && typeof Promise !== 'undefined') {
-      return new Promise(resolve => {
-        this.history.replace(location, resolve)
+      return new Promise((resolve, reject) => {
+        this.history.replace(location, resolve, reject)
       })
     } else {
       this.history.replace(location, onComplete, onAbort)

--- a/src/index.js
+++ b/src/index.js
@@ -151,11 +151,25 @@ export default class VueRouter {
   }
 
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
-    this.history.push(location, onComplete, onAbort)
+    // $flow-disable-line
+    if (!onComplete && !onAbort && typeof Promise !== 'undefined') {
+      return new Promise(resolve => {
+        this.history.push(location, resolve)
+      })
+    } else {
+      this.history.push(location, onComplete, onAbort)
+    }
   }
 
   replace (location: RawLocation, onComplete?: Function, onAbort?: Function) {
-    this.history.replace(location, onComplete, onAbort)
+    // $flow-disable-line
+    if (!onComplete && !onAbort && typeof Promise !== 'undefined') {
+      return new Promise(resolve => {
+        this.history.replace(location, resolve)
+      })
+    } else {
+      this.history.replace(location, onComplete, onAbort)
+    }
   }
 
   go (n: number) {

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -152,7 +152,7 @@ describe('router.push/replace', () => {
     })
   })
   describe('callbacks', () => {
-    it('push with callback return undefined', done => {
+    it('push does not return a Promise when a callback is passed', done => {
       expect(router.push('/foo', done)).toEqual(undefined)
     })
 
@@ -173,7 +173,7 @@ describe('router.push/replace', () => {
       })
     })
 
-    it('replace with callback return undefined', done => {
+    it('replace does not return a Promise when a callback is passed', done => {
       expect(router.replace('/foo', done)).toEqual(undefined)
     })
 

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -152,6 +152,10 @@ describe('router.push/replace', () => {
     })
   })
   describe('callbacks', () => {
+    it('push with callback return undefined', done => {
+      expect(router.push('/foo', done)).toEqual(undefined)
+    })
+
     it('push complete', done => {
       router.push('/foo', () => {
         expect(calls).toEqual([1, 2, 3, 4])
@@ -167,6 +171,10 @@ describe('router.push/replace', () => {
         expect(spy2).toHaveBeenCalled()
         done()
       })
+    })
+
+    it('replace with callback return undefined', done => {
+      expect(router.replace('/foo', done)).toEqual(undefined)
     })
 
     it('replace complete', done => {
@@ -188,10 +196,6 @@ describe('router.push/replace', () => {
   })
 
   describe('promises', () => {
-    it('push with callback return undefined', done => {
-      expect(router.push('/foo', done)).toEqual(undefined)
-    })
-
     it('push complete', done => {
       router.push('/foo')
         .then(spy1)
@@ -209,10 +213,6 @@ describe('router.push/replace', () => {
         expect(spy1).not.toHaveBeenCalled()
         done()
       })
-    })
-
-    it('replace with callback return undefined', done => {
-      expect(router.replace('/foo', done)).toEqual(undefined)
     })
 
     it('replace complete', done => {

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -118,7 +118,7 @@ describe('router.addRoutes', () => {
   })
 })
 
-describe('router.push/replace callbacks', () => {
+describe('router.push/replace', () => {
   let calls = []
   let router, spy1, spy2
 
@@ -151,38 +151,87 @@ describe('router.push/replace callbacks', () => {
       }, 1)
     })
   })
+  describe('callbacks', () => {
+    it('push complete', done => {
+      router.push('/foo', () => {
+        expect(calls).toEqual([1, 2, 3, 4])
+        done()
+      })
+    })
 
-  it('push complete', done => {
-    router.push('/foo', () => {
-      expect(calls).toEqual([1, 2, 3, 4])
-      done()
+    it('push abort', done => {
+      router.push('/foo', spy1, spy2)
+      router.push('/bar', () => {
+        expect(calls).toEqual([1, 1, 2, 2])
+        expect(spy1).not.toHaveBeenCalled()
+        expect(spy2).toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it('replace complete', done => {
+      router.replace('/foo', () => {
+        expect(calls).toEqual([1, 2, 3, 4])
+        done()
+      })
+    })
+
+    it('replace abort', done => {
+      router.replace('/foo', spy1, spy2)
+      router.replace('/bar', () => {
+        expect(calls).toEqual([1, 1, 2, 2])
+        expect(spy1).not.toHaveBeenCalled()
+        expect(spy2).toHaveBeenCalled()
+        done()
+      })
     })
   })
 
-  it('push abort', done => {
-    router.push('/foo', spy1, spy2)
-    router.push('/bar', () => {
-      expect(calls).toEqual([1, 1, 2, 2])
-      expect(spy1).not.toHaveBeenCalled()
-      expect(spy2).toHaveBeenCalled()
-      done()
+  describe('promises', () => {
+    it('push with callback return undefined', done => {
+      expect(router.push('/foo', done)).toEqual(undefined)
     })
-  })
 
-  it('replace complete', done => {
-    router.replace('/foo', () => {
-      expect(calls).toEqual([1, 2, 3, 4])
-      done()
+    it('push complete', done => {
+      router.push('/foo')
+        .then(spy1)
+        .finally(() => {
+          expect(calls).toEqual([1, 2, 3, 4])
+          expect(spy1).toHaveBeenCalledWith(router.currentRoute)
+          done()
+        })
     })
-  })
 
-  it('replace abort', done => {
-    router.replace('/foo', spy1, spy2)
-    router.replace('/bar', () => {
-      expect(calls).toEqual([1, 1, 2, 2])
-      expect(spy1).not.toHaveBeenCalled()
-      expect(spy2).toHaveBeenCalled()
-      done()
+    it('push abort', done => {
+      router.push('/foo')
+      router.push('/bar').finally(() => {
+        expect(calls).toEqual([1, 1, 2, 2])
+        expect(spy1).not.toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it('replace with callback return undefined', done => {
+      expect(router.replace('/foo', done)).toEqual(undefined)
+    })
+
+    it('replace complete', done => {
+      router.replace('/foo')
+        .then(spy1)
+        .finally(() => {
+          expect(calls).toEqual([1, 2, 3, 4])
+          expect(spy1).toHaveBeenCalledWith(router.currentRoute)
+          done()
+        })
+    })
+
+    it('replace abort', done => {
+      router.replace('/foo')
+      router.replace('/bar').finally(() => {
+        expect(calls).toEqual([1, 1, 2, 2])
+        expect(spy1).not.toHaveBeenCalled()
+        done()
+      })
     })
   })
 })

--- a/test/unit/specs/api.spec.js
+++ b/test/unit/specs/api.spec.js
@@ -207,10 +207,11 @@ describe('router.push/replace', () => {
     })
 
     it('push abort', done => {
-      router.push('/foo')
+      router.push('/foo').catch(spy2)
       router.push('/bar').finally(() => {
         expect(calls).toEqual([1, 1, 2, 2])
         expect(spy1).not.toHaveBeenCalled()
+        expect(spy2).toHaveBeenCalled()
         done()
       })
     })
@@ -226,10 +227,11 @@ describe('router.push/replace', () => {
     })
 
     it('replace abort', done => {
-      router.replace('/foo')
+      router.replace('/foo').catch(spy2)
       router.replace('/bar').finally(() => {
         expect(calls).toEqual([1, 1, 2, 2])
         expect(spy1).not.toHaveBeenCalled()
+        expect(spy2).toHaveBeenCalled()
         done()
       })
     })

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -23,8 +23,10 @@ export declare class VueRouter {
   beforeEach (guard: NavigationGuard): Function;
   beforeResolve (guard: NavigationGuard): Function;
   afterEach (hook: (to: Route, from: Route) => any): Function;
-  push (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): Promise<Route> | void;
-  replace (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): Promise<Route> | void;
+  push (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): void;
+  replace (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): void;
+  push (location: RawLocation): Promise<Route>;
+  replace (location: RawLocation): Promise<Route>;
   go (n: number): void;
   back (): void;
   forward (): void;

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -23,8 +23,8 @@ export declare class VueRouter {
   beforeEach (guard: NavigationGuard): Function;
   beforeResolve (guard: NavigationGuard): Function;
   afterEach (hook: (to: Route, from: Route) => any): Function;
-  push (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): void;
-  replace (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): void;
+  push (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): Promise<Route> | void;
+  replace (location: RawLocation, onComplete?: Function, onAbort?: ErrorHandler): Promise<Route> | void;
   go (n: number): void;
   back (): void;
   forward (): void;


### PR DESCRIPTION
Closing(#1769)

Changing behaviour of `push` `replace` to return promise when no callback is provided.
