### PR TITLE
fix(ssr): Memory leak in poll method (fix #2606).

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -177,8 +177,14 @@ export class History {
     }
 
     runQueue(queue, iterator, () => {
+      const app = this.router.app
       const postEnterCbs = []
-      const isValid = () => this.current === route
+      const isValid = () => {
+        if (app && app._isBeingDestroyed) {
+          return false
+        }
+        return this.current === route
+      }
       // wait until async components are resolved before
       // extracting in-component enter guards
       const enterGuards = extractEnterGuards(activated, postEnterCbs, isValid)
@@ -189,8 +195,8 @@ export class History {
         }
         this.pending = null
         onComplete(route)
-        if (this.router.app) {
-          this.router.app.$nextTick(() => {
+        if (app) {
+          app.$nextTick(() => {
             postEnterCbs.forEach(cb => {
               cb()
             })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Fix #2606.

This fix depends on the following being merged first to work: https://github.com/vuejs/vue/pull/9479

Fixes memory leak in `poll` method when a Vue app is created per request, which is typical in SSR.

In particular, the leak happens when:

1. The `router-view` is conditioned to appear upon a variable that never becomes true.
```html
<div id="app">
  <div v-if="condition">
    <router-view />
  </div>
</div>
```

2. A `beforeRouteEnter` guard is defined in the view in the following way:
```es6
export default {
  beforeRouteEnter(to, from, next) {
    // Poll happens only if you pass in a function to next(...)
    next(vm => {})
  }
}
```
