### PR TITLE
parameters should be placed before hash(fix #2876)

### DIFF
--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -142,7 +142,7 @@ function getUrl (path) {
   const query = searchPos > -1 ? base.slice(searchPos) : ''
   base = query ? base.slice(0, searchPos) : base
 
-  return `${base}#${path + query}`
+  return `${base}${query}#${path}`
 }
 
 function pushHash (path) {

--- a/test/e2e/specs/hash-mode.js
+++ b/test/e2e/specs/hash-mode.js
@@ -62,13 +62,13 @@ module.exports = {
       // https://github.com/vuejs/vue-router/issues/2125
       .url('http://localhost:8080/hash-mode/?key=foo')
       .waitForElementVisible('#app', 1000)
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/?key=foo')
+      .assert.urlEquals('http://localhost:8080/hash-mode/?key=foo#/')
       .url('http://localhost:8080/hash-mode?key=foo')
       .waitForElementVisible('#app', 1000)
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/?key=foo')
+      .assert.urlEquals('http://localhost:8080/hash-mode/?key=foo#/')
       .url('http://localhost:8080/hash-mode?key=foo#other')
       .waitForElementVisible('#app', 1000)
-      .assert.urlEquals('http://localhost:8080/hash-mode/#/other?key=foo')
+      .assert.urlEquals('http://localhost:8080/hash-mode/?key=foo#/other')
       .end()
   }
 }


### PR DESCRIPTION
fix #2876

The URI should always be conform to the URI generic syntax 
scheme:[//authority]path[?query][#fragment]
Otherwise most of the lib or code which get the parameters from the URI will fail.