### PR TITLE
docs(guide): add note to props function for named views

### DIFF
--- a/docs/guide/essentials/passing-props.md
+++ b/docs/guide/essentials/passing-props.md
@@ -73,3 +73,25 @@ The URL `/search?q=vue` would pass `{query: 'vue'}` as props to the `SearchUser`
 Try to keep the `props` function stateless, as it's only evaluated on route changes. Use a wrapper component if you need state to define the props, that way vue can react to state changes.
 
 For advanced usage, check out the [example](https://github.com/vuejs/vue-router/blob/dev/examples/route-props/app.js).
+
+::: tip Note when using Named Views
+Specify a function for each Named View under the `props` object.
+
+```js
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/users', 
+      components: {
+        default: UsersList,
+        sidebar: UsersSidebar
+      }, 
+      props: {
+        default: (route) => ({ user: route.params.id }),
+        sidebar: (route) => ({ filters: route.query }) 
+      }
+    }
+  ]
+})
+```
+:::


### PR DESCRIPTION
Added a note to the end of the Functions Mode. A couple of us were stuck on using prop functions for Named Views, it's simple yet easily overlooked. Thought this might help other devs who run into the same issue.