### PR TITLE
fix: publish should include all files under src

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "typings": "types/index.d.ts",
   "files": [
-    "src/*.js",
+    "src",
     "dist/*.js",
     "types/*.d.ts"
   ],


### PR DESCRIPTION
Currently the npm package only includes 4 js files under src, all folders are missing.
