### PR TITLE
fix misspell in examples

### DIFF
--- a/examples/hash-mode/app.js
+++ b/examples/hash-mode/app.js
@@ -32,7 +32,7 @@ new Vue({
   router,
   template: `
     <div id="app">
-      <h1>Basic</h1>
+      <h1>Mode: 'hash'</h1>
       <ul>
         <li><router-link to="/">/</router-link></li>
         <li><router-link to="/foo">/foo</router-link></li>

--- a/examples/lazy-loading/app.js
+++ b/examples/lazy-loading/app.js
@@ -69,7 +69,7 @@ new Vue({
   router,
   template: `
     <div id="app">
-      <h1>Basic</h1>
+      <h1>Lazy Loading</h1>
       <ul>
         <li><router-link to="/">/</router-link></li>
         <li><router-link to="/foo">/foo</router-link></li>


### PR DESCRIPTION
change `<h1>` text in examples