### PR TITLE
Not only string can be passed as a param in Location

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -127,7 +127,7 @@ export interface Location {
   path?: string
   hash?: string
   query?: Dictionary<string | (string | null)[] | null | undefined>
-  params?: Dictionary<string>
+  params?: Dictionary<string | number | boolean>
   append?: boolean
   replace?: boolean
 }


### PR DESCRIPTION
When I do the following:

```
this.$router.push({ name: 'somepage', params: { someParam: false } });
```

The following error occurs:

![image](https://user-images.githubusercontent.com/12934957/66199491-02a3f980-e69f-11e9-824e-6c42244de5cc.png)

When I console.log `this.$route.params` in my somepage route, the `someParam` variable with `false` as value exists.

So update the type to allow more than a string.