### PR TITLE
feat(history): allow same route navigation

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -7,7 +7,7 @@ import VueRouter from 'vue-router'
 Vue.use(VueRouter)
 
 // 2. Define route components
-const Home = { template: '<div>home</div>' }
+const Home = { template: '<div>home</div>', data: () => { console.log('data reprocessed'); return {} } }
 const Foo = { template: '<div>foo</div>' }
 const Bar = { template: '<div>bar</div>' }
 const Unicode = { template: '<div>unicode</div>' }
@@ -53,7 +53,7 @@ new Vue({
       <pre id="counter">{{ n }}</pre>
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
-      <router-view class="view"></router-view>
+      <router-view class="view" :key="$route.id"></router-view>
     </div>
   `,
 

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -5,7 +5,7 @@ import type Router from '../index'
 import { inBrowser } from '../util/dom'
 import { runQueue } from '../util/async'
 import { warn, isError, isExtendedError } from '../util/warn'
-import { START, isSameRoute } from '../util/route'
+import { START } from '../util/route'
 import {
   flatten,
   flatMapComponents,
@@ -115,14 +115,6 @@ export class History {
         }
       }
       onAbort && onAbort(err)
-    }
-    if (
-      isSameRoute(route, current) &&
-      // in the case the route map has been dynamically appended to
-      route.matched.length === current.matched.length
-    ) {
-      this.ensureURL()
-      return abort(new NavigationDuplicated(route))
     }
 
     const { updated, deactivated, activated } = resolveQueue(
@@ -240,15 +232,18 @@ function resolveQueue (
 } {
   let i
   const max = Math.max(current.length, next.length)
+
+  // Get the index of the first non-matching route pair
   for (i = 0; i < max; i++) {
     if (current[i] !== next[i]) {
       break
     }
   }
+
   return {
     updated: next.slice(0, i),
-    activated: next.slice(i),
-    deactivated: current.slice(i)
+    activated: next,
+    deactivated: current
   }
 }
 

--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -49,28 +49,21 @@ export class HashHistory extends History {
 
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
-    this.transitionTo(
-      location,
-      route => {
-        pushHash(route.fullPath)
-        handleScroll(this.router, route, fromRoute, false)
-        onComplete && onComplete(route)
-      },
-      onAbort
-    )
+    this.transitionTo(location, route => {
+      const fn = fromRoute.fullPath === route.fullPath ? replaceHash : pushHash
+      fn(route.fullPath)
+      handleScroll(this.router, route, fromRoute, false)
+      onComplete && onComplete(route)
+    }, onAbort)
   }
 
   replace (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
-    this.transitionTo(
-      location,
-      route => {
-        replaceHash(route.fullPath)
-        handleScroll(this.router, route, fromRoute, false)
-        onComplete && onComplete(route)
-      },
-      onAbort
-    )
+    this.transitionTo(location, route => {
+      replaceHash(route.fullPath)
+      handleScroll(this.router, route, fromRoute, false)
+      onComplete && onComplete(route)
+    }, onAbort)
   }
 
   go (n: number) {

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -44,7 +44,8 @@ export class HTML5History extends History {
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {
     const { current: fromRoute } = this
     this.transitionTo(location, route => {
-      pushState(cleanPath(this.base + route.fullPath))
+      const fn = fromRoute.fullPath === route.fullPath ? replaceState : pushState
+      fn(cleanPath(this.base + route.fullPath))
       handleScroll(this.router, route, fromRoute, false)
       onComplete && onComplete(route)
     }, onAbort)

--- a/src/util/route.js
+++ b/src/util/route.js
@@ -19,6 +19,7 @@ export function createRoute (
   } catch (e) {}
 
   const route: Route = {
+    id: Date.now(),
     name: location.name || (record && record.name),
     meta: (record && record.meta) || {},
     path: location.path || '/',

--- a/test/e2e/specs/navigation-guards.js
+++ b/test/e2e/specs/navigation-guards.js
@@ -150,7 +150,7 @@ module.exports = {
       .assert.containsText('#bre-order', 'parent mixin child 2')
       .click('#nested-parent a')
       .assert.urlEquals('http://localhost:8080/navigation-guards/parent/child/1')
-      .assert.containsText('#bre-order', 'parent mixin child 2 mixin child 1')
+      .assert.containsText('#bre-order', 'parent mixin child 2 parent mixin child 1')
       .end()
   }
 }


### PR DESCRIPTION
To get the component to build a fresh instance you need to add a key attribute i.e `<router-view :key="$route.id"></router-view>`. Regardless the vue-router hooks still fire when reloading.

Issue: #974 
Related: #2957 #2430 
