### PR TITLE
docs: example is added with a server written in Go

### DIFF
--- a/docs-gitbook/de/essentials/history-mode.md
+++ b/docs-gitbook/de/essentials/history-mode.md
@@ -55,12 +55,14 @@ import (
 )
 var httpPort = "80"
 var indexFile = "index.html"
+var folder = "./"
+
 func serverHandler(w http.ResponseWriter, r *http.Request) {
-	if _, err := os.Stat(indexFile); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if _, err := os.Stat(folder + r.URL.Path); err != nil {
+		http.ServeFile(w, r, folder+"/index.html")
 		return
 	}
-	http.ServeFile(w, r, indexFile)
+	http.ServeFile(w, r, folder+r.URL.Path)
 }
 func main() {
 	r := mux.NewRouter()

--- a/docs-gitbook/de/essentials/history-mode.md
+++ b/docs-gitbook/de/essentials/history-mode.md
@@ -44,6 +44,32 @@ location / {
 
 Für Node.js/Express benutz du am besten [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback).
 
+#### Golang (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 ## Warnung
 
 Es gibt einen kleinen Nachteil: Der Server wird  keine 404-Fehler mehr melden, da alle nicht gefundenen Pfade zur `index.html` führen. Um das zu beheben, solltest du eine Sammel-Route in der Vue-App für die 404-Seite definieren.

--- a/docs-gitbook/es/essentials/history-mode.md
+++ b/docs-gitbook/es/essentials/history-mode.md
@@ -40,9 +40,35 @@ location / {
 }
 ```
 
-#### Node.js (Express)
+#### Node.js utilizando (Express)
 
 Para Node.js/Express, considera utilizar el middleware [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback).
+
+#### Golang utilizando (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
 
 ## Deventajas
 

--- a/docs-gitbook/fr/essentials/history-mode.md
+++ b/docs-gitbook/fr/essentials/history-mode.md
@@ -68,6 +68,33 @@ http.createServer((req, res) => {
 
 Pour Node.js avec Express, vous pouvez utiliser le [middleware connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback).
 
+
+#### Golang avec (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 1. Instaler [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs-gitbook/ja/essentials/history-mode.md
+++ b/docs-gitbook/ja/essentials/history-mode.md
@@ -70,6 +70,34 @@ http.createServer((req, res) => {
 
 Node.js/Express では [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback) の利用を検討してください。
 
+
+#### Golang (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
+
 #### Internet Information Services (IIS)
 
 1. [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite) をインストール

--- a/docs-gitbook/kr/essentials/history-mode.md
+++ b/docs-gitbook/kr/essentials/history-mode.md
@@ -69,6 +69,33 @@ http.createServer((req, res) => {
 
 Node.js/Express의 경우 [connect-history-api-fallback 미들웨어](https://github.com/bripkens/connect-history-api-fallback)를 고려해보세요.
 
+#### Golang (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
+
 #### Internet Information Services (IIS)
 
 ```

--- a/docs-gitbook/ru/essentials/history-mode.md
+++ b/docs-gitbook/ru/essentials/history-mode.md
@@ -68,6 +68,33 @@ http.createServer((req, res) => {
 
 При использовании Node.js/Express, мы рекомендуем пользоваться [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback).
 
+
+#### Golang использованием (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 1. Установить [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs/fr/guide/essentials/history-mode.md
+++ b/docs/fr/guide/essentials/history-mode.md
@@ -70,6 +70,32 @@ http.createServer((req, res) => {
 
 Pour Node.js avec Express, vous pouvez utiliser le [middleware connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback).
 
+#### Golang avec (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 ### Internet Information Services (IIS)
 
 1. Instaler [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -72,6 +72,33 @@ http.createServer((req, res) => {
 
 For Node.js/Express, consider using [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback).
 
+
+#### Golang with (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 1. Install [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs/ja/guide/essentials/history-mode.md
+++ b/docs/ja/guide/essentials/history-mode.md
@@ -70,6 +70,33 @@ http.createServer((req, res) => {
 
 Node.js/Express では [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback) の利用を検討してください。
 
+
+#### Golang (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 1. [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite) をインストール

--- a/docs/kr/guide/essentials/history-mode.md
+++ b/docs/kr/guide/essentials/history-mode.md
@@ -69,6 +69,33 @@ http.createServer((req, res) => {
 
 Node.js/Express의 경우 [connect-history-api-fallback 미들웨어](https://github.com/bripkens/connect-history-api-fallback)를 고려해보세요.
 
+
+#### (gorilla/mux)와 Golang 
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 ```

--- a/docs/ru/guide/essentials/history-mode.md
+++ b/docs/ru/guide/essentials/history-mode.md
@@ -70,6 +70,33 @@ http.createServer((req, res) => {
 
 При использовании Node.js/Express, мы рекомендуем пользоваться [connect-history-api-fallback middleware](https://github.com/bripkens/connect-history-api-fallback).
 
+
+#### Golang использованием (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 1. Установить [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)

--- a/docs/zh/guide/essentials/history-mode.md
+++ b/docs/zh/guide/essentials/history-mode.md
@@ -70,6 +70,32 @@ http.createServer((req, res) => {
 
 对于 Node.js/Express，请考虑使用 [connect-history-api-fallback 中间件](https://github.com/bripkens/connect-history-api-fallback)。
 
+#### Golang 的 (gorilla/mux)
+
+```go
+package main
+import (
+	"net/http"
+	"os"
+	"github.com/gorilla/mux"
+)
+var httpPort = "80"
+var indexFile = "index.html"
+func serverHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(indexFile); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, indexFile)
+}
+func main() {
+	r := mux.NewRouter()
+	r.NotFoundHandler = r.NewRoute().HandlerFunc(serverHandler).GetHandler()
+	http.Handle("/", r)
+	http.ListenAndServe(":"+httpPort, nil)
+}
+```
+
 #### Internet Information Services (IIS)
 
 1. 安装 [IIS UrlRewrite](https://www.iis.net/downloads/microsoft/url-rewrite)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

#### Reason for the proposal:
Because different servers already support **golang**. I think it's a good idea to add golang as an example.

#### why gorilla/mux:
Since it complies with the net / http standards of golang. It has no conflicts with the standard library
> The code (**Golang**) has been verified and works correctly.

#### What exactly did you modify?
These changes only include modifications to the **'history-mode.md**' files. Adding the example of a server in **Go**

#### Did you implement the example in all languages?
Yes

#### Notes
> I previously created a **pull request #2961**, but the implementation was not complete and **created** a **new pull request**.


