### PR TITLE
feat: add destroy method, remove event listener on destroy

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -22,6 +22,7 @@ export class History {
   readyCbs: Array<Function>;
   readyErrorCbs: Array<Function>;
   errorCbs: Array<Function>;
+  removeEventListenerCbs: Array<Function>;
 
   // implemented by sub-classes
   +go: (n: number) => void;
@@ -40,6 +41,7 @@ export class History {
     this.readyCbs = []
     this.readyErrorCbs = []
     this.errorCbs = []
+    this.removeEventListenerCbs = []
   }
 
   listen (cb: Function) {
@@ -189,6 +191,10 @@ export class History {
     this.router.afterHooks.forEach(hook => {
       hook && hook(route, prev)
     })
+  }
+
+  destroy () {
+    this.removeEventListenerCbs.forEach(cb => { cb() })
   }
 }
 

--- a/src/history/hash.js
+++ b/src/history/hash.js
@@ -25,10 +25,12 @@ export class HashHistory extends History {
     const supportsScroll = supportsPushState && expectScroll
 
     if (supportsScroll) {
-      setupScroll()
+      const uninstall = setupScroll()
+      this.removeEventListenerCbs.push(uninstall)
     }
 
-    window.addEventListener(supportsPushState ? 'popstate' : 'hashchange', () => {
+    const eventName = supportsPushState ? 'popstate' : 'hashchange'
+    const listener = () => {
       const current = this.current
       if (!ensureSlash()) {
         return
@@ -41,7 +43,12 @@ export class HashHistory extends History {
           replaceHash(route.fullPath)
         }
       })
-    })
+    }
+    window.addEventListener(eventName, listener)
+    const uninstall = () => {
+      window.removeEventListener(eventName, listener)
+    }
+    this.removeEventListenerCbs.push(uninstall)
   }
 
   push (location: RawLocation, onComplete?: Function, onAbort?: Function) {

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -15,11 +15,12 @@ export class HTML5History extends History {
     const supportsScroll = supportsPushState && expectScroll
 
     if (supportsScroll) {
-      setupScroll()
+      const uninstall = setupScroll()
+      this.removeEventListenerCbs.push(uninstall)
     }
 
     const initLocation = getLocation(this.base)
-    window.addEventListener('popstate', e => {
+    const listener = e => {
       const current = this.current
 
       // Avoiding first `popstate` event dispatched in some browsers but first
@@ -34,7 +35,12 @@ export class HTML5History extends History {
           handleScroll(router, route, current, true)
         }
       })
-    })
+    }
+    window.addEventListener('popstate', listener)
+    const uninstall = () => {
+      window.removeEventListener('popstate', listener)
+    }
+    this.removeEventListenerCbs.push(uninstall)
   }
 
   go (n: number) {

--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,10 @@ export default class VueRouter {
       this.history.transitionTo(this.history.getCurrentLocation())
     }
   }
+
+  destroy () {
+    this.history.destroy()
+  }
 }
 
 function registerHook (list: Array<any>, fn: Function): Function {

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -10,12 +10,17 @@ export function setupScroll () {
   // Fix for #1585 for Firefox
   // Fix for #2195 Add optional third attribute to workaround a bug in safari https://bugs.webkit.org/show_bug.cgi?id=182678
   window.history.replaceState({ key: getStateKey() }, '', window.location.href.replace(window.location.origin, ''))
-  window.addEventListener('popstate', e => {
+  const listener = e => {
     saveScrollPosition()
     if (e.state && e.state.key) {
       setStateKey(e.state.key)
     }
-  })
+  }
+  window.addEventListener('popstate', listener)
+
+  return function uninstall () {
+    window.removeEventListener('popstate', listener)
+  }
 }
 
 export function handleScroll (


### PR DESCRIPTION
I need to implement a micro-frontend. When I switch between applications, I have a problem and I can't remove the bound event, which prevents multiple instances from being present at the same time. so~, I need manually remove those events