### PR TITLE
Allow scrollBehavior selectors to match ids with unescaped CSS special characters (feature request #3008)

### DIFF
--- a/examples/scroll-behavior/app.js
+++ b/examples/scroll-behavior/app.js
@@ -13,6 +13,7 @@ const Bar = {
       <p id="anchor" style="height:500px">Anchor</p>
       <p id="anchor2" style="height:500px">Anchor2</p>
       <p id="1number">with number</p>
+      <p id="1number/2number">with CSS special characters</p>
     </div>
   `
 }
@@ -37,8 +38,8 @@ const scrollBehavior = function (to, from, savedPosition) {
         position.offset = { y: 100 }
       }
 
-      // bypass #1number check
-      if (/^#\d/.test(to.hash) || document.querySelector(to.hash)) {
+      // bypass #1number && #1number/2number check
+      if (/^#[^, ]+$/.test(to.hash) || document.querySelector(to.hash)) {
         return position
       }
 
@@ -89,6 +90,7 @@ new Vue({
         <li><router-link to="/bar#anchor">/bar#anchor</router-link></li>
         <li><router-link to="/bar#anchor2">/bar#anchor2</router-link></li>
         <li><router-link to="/bar#1number">/bar#1number</router-link></li>
+        <li><router-link to="/bar#1number/2number">/bar#1number/2number</router-link></li>
       </ul>
       <transition name="fade" mode="out-in" @after-leave="afterLeave">
         <router-view class="view"></router-view>

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -121,14 +121,16 @@ function isNumber (v: any): boolean {
   return typeof v === 'number'
 }
 
-const hashStartsWithNumberRE = /^#\d/
+const selectorLooksLikeIdRE = /^#[^, ]+$/
 
 function scrollToPosition (shouldScroll, position) {
   const isObject = typeof shouldScroll === 'object'
   if (isObject && typeof shouldScroll.selector === 'string') {
+    // getElementById is used only where a selector looks like a single [id] ... this allows for use of CSS
+    // 'special characters' that would otherwise fail in querySelector without escaping, e.g. "#one/two"
     // getElementById would still fail if the selector contains a more complicated query like #main[data-attr]
     // but at the same time, it doesn't make much sense to select an element with an id and an extra selector
-    const el = hashStartsWithNumberRE.test(shouldScroll.selector) // $flow-disable-line
+    const el = selectorLooksLikeIdRE.test(shouldScroll.selector) // $flow-disable-line
       ? document.getElementById(shouldScroll.selector.slice(1)) // $flow-disable-line
       : document.querySelector(shouldScroll.selector)
 

--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -11,7 +11,7 @@ module.exports = {
     browser
       .url('http://localhost:8080/scroll-behavior/')
       .waitForElementVisible('#app', 1000)
-      .assert.count('li a', 6)
+      .assert.count('li a', 7)
       .assert.containsText('.view', 'home')
 
       .execute(function () {
@@ -126,6 +126,16 @@ module.exports = {
         },
         null,
         'scroll to anchor that starts with number'
+      )
+      .execute(function () {
+        document.querySelector('li:nth-child(7) a').click()
+      })
+      .assert.evaluate(
+        function () {
+          return document.getElementById('1number/2number').getBoundingClientRect().top < 1
+        },
+        null,
+        'scroll to anchor that includes CSS special characters'
       )
       .end()
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
As per the title and the original feature request #3008 this PR means a wider range of selectors are passed to `document.getElementById`, resulting in more straightforward use of `scrollBehavior` with e.g. `to.hash`