### PR TITLE
chore: upgrade path-to-regexp to v1.8.0 (fix #2924)

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -27,7 +27,8 @@ fs.readdirSync(__dirname).forEach(file => {
 
 app.use(express.static(__dirname))
 
+const host = process.env.HOST || 'localhost'
 const port = process.env.PORT || 8080
-module.exports = app.listen(port, () => {
-  console.log(`Server listening on http://localhost:${port}, Ctrl+C to stop`)
+module.exports = app.listen(port, host, () => {
+  console.log(`Server listening on http://${host}:${port}, Ctrl+C to stop`)
 })

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint-staged": "^8.2.0",
     "nightwatch": "^1.1.13",
     "nightwatch-helpers": "^1.0.0",
-    "path-to-regexp": "^1.7.0",
+    "path-to-regexp": "^1.8.0",
     "rollup": "^1.20.1",
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-commonjs": "^10.0.2",

--- a/test/unit/specs/location.spec.js
+++ b/test/unit/specs/location.spec.js
@@ -79,13 +79,13 @@ describe('Location utils', () => {
     })
 
     it('relative params (non-named)', () => {
-      const loc = normalizeLocation({ params: { lang: 'fr' }}, {
+      const loc = normalizeLocation({ params: { lang: 'FR' }}, {
         path: '/en/foo',
         params: { lang: 'en', id: 'foo' },
-        matched: [{ path: '/:lang/:id' }]
+        matched: [{ path: '/:lang(en|fr)/:id' }]
       })
       expect(loc._normalized).toBe(true)
-      expect(loc.path).toBe('/fr/foo')
+      expect(loc.path).toBe('/FR/foo')
     })
 
     it('relative append', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,10 +7769,17 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.0.3, path-to-regexp@^1.7.0:
+path-to-regexp@^1.0.3:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
+path-to-regexp@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

See issue https://github.com/vuejs/vue-router/issues/2925 and the commit messages.

The server host configuration commit could be omitted but I'm running Node on a remote docker cluster which means I need to set the host to `0.0.0.0`. To be able to run the e2e tests I actually also needed to add `'no-sandbox', 'headless', 'disable-gpu', 'disable-dev-shm-usage'` to `chromeOptions.args` in `test/e2e/nightwatch.config.js`. Otherwise Chrome wont be able to start in a docker container.
