### PR TITLE
Remove broken gitbook links

### DIFF
--- a/docs-gitbook/LANGS.md
+++ b/docs-gitbook/LANGS.md
@@ -1,7 +1,5 @@
-* [English](en/)
 * [French](fr/)
 * [Japanese](ja/)
-* [中文](zh-cn/)
 * [German](de/)
 * [Русский](ru/)
 * [한국어(Korean)](kr/)


### PR DESCRIPTION
The folders "en" and "zh-cn" don't exist within "docs-gitbook" so I removed them from LANGS.md

If they have some different use, please let me know :)

Cheers! :beer: