### PR TITLE
Docs: Updates to History Mode for Apache w/ subfolder

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -23,7 +23,7 @@ Not to worry: To fix the issue, all you need to do is add a simple catch-all fal
 
 #### Apache
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteBase /

--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -19,7 +19,7 @@ Not to worry: To fix the issue, all you need to do is add a simple catch-all fal
 
 ## Example Server Configurations
 
-**Note**: The following examples assume you are serving your app from the root folder. If you deploy to a subfolder, you should use [the `publicPath` option of Vue CLI](https://cli.vuejs.org/config/#publicpath) and the related [`base` property of the router](https://router.vuejs.org/api/#base). You also need to adjust the examples below to use the subfolder instead of the root folder (e.g. replacing `RewriteBase /` with `RewriteBase /name-of-your-subfolder/`).
+**Note**: The following examples assume you are serving your app from the root folder. If you deploy to a subfolder, you should use [the `publicPath` option of Vue CLI](https://cli.vuejs.org/config/#publicpath) and the related [`base` property of the router](https://router.vuejs.org/api/#base). You also need to adjust the examples below to use the subfolder instead of the root folder (e.g. replacing `RewriteBase /` with `RewriteBase /name-of-your-subfolder`, `RewriteRule ^index\.html$ -[L]` with `RewriteRule ^name-of-your-subfolder/index\.html$ -[L]` and `RewriteRule . /index.html [L]` with `RewriteRule . /name-of-your-subfolder/index.html [L]`).
 
 #### Apache
 

--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -19,7 +19,7 @@ Not to worry: To fix the issue, all you need to do is add a simple catch-all fal
 
 ## Example Server Configurations
 
-**Note**: The following examples assume you are serving your app from the root folder. If you deploy to a subfolder, you should use [the `publicPath` option of Vue CLI](https://cli.vuejs.org/config/#publicpath) and the related [`base` property of the router](https://router.vuejs.org/api/#base). You also need to adjust the examples below to use the subfolder instead of the root folder (e.g. replacing `RewriteBase /` with `RewriteBase /name-of-your-subfolder`, `RewriteRule ^index\.html$ -[L]` with `RewriteRule ^name-of-your-subfolder/index\.html$ -[L]` and `RewriteRule . /index.html [L]` with `RewriteRule . /name-of-your-subfolder/index.html [L]`).
+**Note**: The following examples assume you are serving your app from the root folder. If you deploy to a subfolder, you should use [the `publicPath` option of Vue CLI](https://cli.vuejs.org/config/#publicpath) and the related [`base` property of the router](https://router.vuejs.org/api/#base). You also need to adjust the examples below to use the subfolder instead of the root folder (e.g. replacing `RewriteBase /` with `RewriteBase /name-of-your-subfolder`.
 
 #### Apache
 
@@ -33,6 +33,8 @@ Not to worry: To fix the issue, all you need to do is add a simple catch-all fal
   RewriteRule . /index.html [L]
 </IfModule>
 ```
+
+If using subfolders, you'll need to adjust `RewriteBase` as per above along with `RewriteRule ^index\.html$ -[L]` to `RewriteRule ^name-of-your-subfolder/index\.html$ -[L]` and `RewriteRule . /index.html [L]` to `RewriteRule . /name-of-your-subfolder/index.html [L]`).
 
 Instead of `mod_rewrite`, you could also use [`FallbackResource`](https://httpd.apache.org/docs/2.2/mod/mod_dir.html#fallbackresource).
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
**Reason**
I had issues getting this to work with the examples in the doc as currently written. It wasn't until I found [this answer on Stack Overflow](https://stackoverflow.com/a/52119508/10577234) where things became clear. Admittedly, I'm not well versed in Apache, but I figured these amendments might better serve others in the future. Per the Stack Overflow answer it seems there was a related [Vue Forum discussion](https://forum.vuejs.org/t/vue-webpack-project-path-change/4993/6) which tells me the scenario is not uncommon.

**What changed?**
I added a few specifics to the Apache example in `history-mode.md` and removed the trailing `/` in the `RewriteBase` example for subfolders. These adjustments mirror how I was able to get my application working when building to a different base path and deploying to Apache.