### PR TITLE
feat(core): add aria-current to active links (close #2116)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -163,6 +163,13 @@ If you add a `target="_blank"` to your `a` element, you must omit the `@click="n
 
   Configure the active CSS class applied when the link is active with exact match. Note the default value can also be configured globally via the `linkExactActiveClass` router constructor option.
 
+### aria-current-value
+
+- type: `'page' | 'step' | 'location' | 'date' | 'time'`
+- default: `"page"`
+
+  Configure the value of `aria-current` when the link is active with exact match. It must be one of the [allowed values for aria-current](https://www.w3.org/TR/wai-aria-1.2/#aria-current) in the ARIA spec. In most cases, the default of `page` should be the best fit.
+
 ## `<router-view>`
 
 The `<router-view>` component is a functional component that renders the matched component for the given path. Components rendered in `<router-view>` can also contain their own `<router-view>`, which will render components for nested paths.

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -8,6 +8,7 @@ import { warn } from '../util/warn'
 // work around weird flow bug
 const toTypes: Array<Function> = [String, Object]
 const eventTypes: Array<Function> = [String, Array]
+let ariaCurrentTypes: 'page' | 'step' | 'location' | 'date' | 'time'
 
 const noop = () => {}
 
@@ -27,7 +28,10 @@ export default {
     replace: Boolean,
     activeClass: String,
     exactActiveClass: String,
-    ariaCurrentValue: 'page' | 'step' | 'location' | 'date' | 'time',
+    ariaCurrentValue: {
+      type: ariaCurrentTypes,
+      default: 'page'
+    },
     event: {
       type: eventTypes,
       default: 'click'
@@ -68,8 +72,7 @@ export default {
       ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
 
-    const ariaCurrentType = this.ariaCurrentValue || 'page'
-    const ariaCurrentValue = classes[exactActiveClass] ? ariaCurrentType : null
+    const ariaCurrentValue = classes[exactActiveClass] ? this.ariaCurrentValue : null
 
     const handler = e => {
       if (guardEvent(e)) {

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -67,6 +67,8 @@ export default {
       ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
 
+    const ariaCurrentValue = classes[activeClass] ? 'page' : null
+
     const handler = e => {
       if (guardEvent(e)) {
         if (this.replace) {
@@ -117,7 +119,7 @@ export default {
 
     if (this.tag === 'a') {
       data.on = on
-      data.attrs = { href }
+      data.attrs = { href, 'aria-current': ariaCurrentValue }
     } else {
       // find the first <a> child and apply listener and href
       const a = findAnchor(this.$slots.default)
@@ -145,6 +147,7 @@ export default {
 
         const aAttrs = (a.data.attrs = extend({}, a.data.attrs))
         aAttrs.href = href
+        aAttrs['aria-current'] = ariaCurrentValue
       } else {
         // doesn't have <a> child, apply listener to self
         data.on = on

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -8,7 +8,6 @@ import { warn } from '../util/warn'
 // work around weird flow bug
 const toTypes: Array<Function> = [String, Object]
 const eventTypes: Array<Function> = [String, Array]
-let ariaCurrentTypes: 'page' | 'step' | 'location' | 'date' | 'time'
 
 const noop = () => {}
 
@@ -29,7 +28,7 @@ export default {
     activeClass: String,
     exactActiveClass: String,
     ariaCurrentValue: {
-      type: ariaCurrentTypes,
+      type: String,
       default: 'page'
     },
     event: {

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -67,7 +67,7 @@ export default {
       ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
 
-    const ariaCurrentValue = classes[activeClass] ? 'page' : null
+    const ariaCurrentValue = classes[exactActiveClass] ? 'page' : null
 
     const handler = e => {
       if (guardEvent(e)) {

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -27,6 +27,7 @@ export default {
     replace: Boolean,
     activeClass: String,
     exactActiveClass: String,
+    ariaCurrentValue: 'page' | 'step' | 'location' | 'date' | 'time',
     event: {
       type: eventTypes,
       default: 'click'
@@ -67,7 +68,8 @@ export default {
       ? classes[exactActiveClass]
       : isIncludedRoute(current, compareTarget)
 
-    const ariaCurrentValue = classes[exactActiveClass] ? 'page' : null
+    const ariaCurrentType = this.ariaCurrentValue || 'page'
+    const ariaCurrentValue = classes[exactActiveClass] ? ariaCurrentType : null
 
     const handler = e => {
       if (guardEvent(e)) {

--- a/test/e2e/specs/active-links.js
+++ b/test/e2e/specs/active-links.js
@@ -71,6 +71,9 @@ module.exports = {
           .cssClassPresent(`li:nth-child(${i}) a`, 'router-link-exact-active')
           .assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
           .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
+        if (i < 19) {
+          browser.assert.not.attributeEquals(`li:nth-child(${i + 1}) a`, 'aria-current', 'page')
+        }
       })
       exactActiveLI &&
         exactActiveLI.forEach(i => {

--- a/test/e2e/specs/active-links.js
+++ b/test/e2e/specs/active-links.js
@@ -31,6 +31,7 @@ module.exports = {
       .assert.attributeContains('li:nth-child(18) a', 'href', '/active-links/redirect-image')
       .assert.attributeContains('li:nth-child(19) a', 'href', '/active-links/redirect-image')
       .assert.containsText('.view', 'Home')
+      .assert.not.attributeEquals(`li:nth-child(3) a`, 'aria-current', 'page')
 
     assertActiveLinks(1, [1, 2], null, [1, 2])
     assertActiveLinks(2, [1, 2], null, [1, 2])
@@ -71,9 +72,6 @@ module.exports = {
           .cssClassPresent(`li:nth-child(${i}) a`, 'router-link-exact-active')
           .assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
           .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
-        if (i < 19) {
-          browser.assert.not.attributeEquals(`li:nth-child(${i + 1}) a`, 'aria-current', 'page')
-        }
       })
       exactActiveLI &&
         exactActiveLI.forEach(i => {

--- a/test/e2e/specs/active-links.js
+++ b/test/e2e/specs/active-links.js
@@ -60,26 +60,24 @@ module.exports = {
     function assertActiveLinks (n, activeA, activeLI, exactActiveA, exactActiveLI) {
       browser.click(`li:nth-child(${n}) a`)
       activeA.forEach(i => {
-        browser
-          .assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
-          .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
+        browser.assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
       })
       activeLI &&
         activeLI.forEach(i => {
-          browser
-            .assert.cssClassPresent(`li:nth-child(${i})`, 'router-link-active')
-            .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
+          browser.assert.cssClassPresent(`li:nth-child(${i})`, 'router-link-active')
         })
       exactActiveA.forEach(i => {
         browser.assert
           .cssClassPresent(`li:nth-child(${i}) a`, 'router-link-exact-active')
           .assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
+          .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
       })
       exactActiveLI &&
         exactActiveLI.forEach(i => {
           browser.assert
             .cssClassPresent(`li:nth-child(${i})`, 'router-link-exact-active')
             .assert.cssClassPresent(`li:nth-child(${i})`, 'router-link-active')
+            .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
         })
     }
   }

--- a/test/e2e/specs/active-links.js
+++ b/test/e2e/specs/active-links.js
@@ -60,11 +60,15 @@ module.exports = {
     function assertActiveLinks (n, activeA, activeLI, exactActiveA, exactActiveLI) {
       browser.click(`li:nth-child(${n}) a`)
       activeA.forEach(i => {
-        browser.assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
+        browser
+          .assert.cssClassPresent(`li:nth-child(${i}) a`, 'router-link-active')
+          .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
       })
       activeLI &&
         activeLI.forEach(i => {
-          browser.assert.cssClassPresent(`li:nth-child(${i})`, 'router-link-active')
+          browser
+            .assert.cssClassPresent(`li:nth-child(${i})`, 'router-link-active')
+            .assert.attributeEquals(`li:nth-child(${i}) a`, 'aria-current', 'page')
         })
       exactActiveA.forEach(i => {
         browser.assert


### PR DESCRIPTION
Hi! First contributor + pretty new to Vue 👋 😄 

This PR adds `aria-current="page"` to active links, and resolves #2116. I made the following two choices:

1. Use `aria-current="page"` over other token values
The original issue mentions allowing custom token values, or future `<router-link>` extension possibilities. That still seems useful, but `aria-current="page"` seems like the right choice at least 90% of the time. The other tokens are either much less common (e.g. `step`) or unlikely to be used with a router at all (e.g. `date`)

2. Use the `activeClass` logic over only applying it to the exact active route
This is more hand-wavy, but seems like the better choice -- URL params shouldn't necessarily affect `aria-current`, and it's not the worst thing to have parent routes also receive `aria-current` if `exact` is not applied.

I'm hoping this is a small enough change that it can go in before the harder work of figuring out how to extend `<router-link>` is done, and it seems like a sensible default even with customization. I've run into some issues using vue-router b/c of this, so I'd personally love to see `aria-current` added :). I'm happy to answer any questions on the accessibility side, and let me know if I missed anything PR-wise. Thanks!
