### PR TITLE
fix: correctly calculate `path` when `pathMatch` is empty string (fix #3106)

### DIFF
--- a/src/util/params.js
+++ b/src/util/params.js
@@ -20,8 +20,8 @@ export function fillParams (
       (regexpCompileCache[path] = Regexp.compile(path))
 
     // Fix #2505 resolving asterisk routes { name: 'not-found', params: { pathMatch: '/not-found' }}
-    // `params.pathMatch === ''` fixes #3106 so that you can work with location descriptor object having params.pathMatch equal to empty string
-    if (params.pathMatch || params.pathMatch === '') params[0] = params.pathMatch
+    // and fix #3106 so that you can work with location descriptor object having params.pathMatch equal to empty string
+    if (typeof params.pathMatch === 'string') params[0] = params.pathMatch
 
     return filler(params, { pretty: true })
   } catch (e) {

--- a/src/util/params.js
+++ b/src/util/params.js
@@ -20,7 +20,8 @@ export function fillParams (
       (regexpCompileCache[path] = Regexp.compile(path))
 
     // Fix #2505 resolving asterisk routes { name: 'not-found', params: { pathMatch: '/not-found' }}
-    if (params.pathMatch) params[0] = params.pathMatch
+    // `params.pathMatch === ''` fixes #3106 so that you can work with location descriptor object having params.pathMatch equal to empty string
+    if (params.pathMatch || params.pathMatch === '') params[0] = params.pathMatch
 
     return filler(params, { pretty: true })
   } catch (e) {

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -85,13 +85,19 @@ describe('Creating Matcher', function () {
     expect(params).toEqual({ pathMatch: '/not-found' })
   })
 
-  it('calculates correctly and without warning the path of a partial asterisk route with a default param name and pathMatch empty string', function () {
+  it('allows an empty pathMatch', function () {
     process.env.NODE_ENV = 'development'
-    const { path } = match(
+    const pathForErrorRoute = match(
       { name: 'error', params: { pathMatch: '' }},
       routes[0]
-    )
+    ).path
+    const pathForNotFoundRoute = match(
+      { name: 'notFound', params: { pathMatch: '' }},
+      routes[0]
+    ).path
+
     expect(console.warn).not.toHaveBeenCalled()
-    expect(path).toEqual('/error/')
+    expect(pathForErrorRoute).toEqual('/error/')
+    expect(pathForNotFoundRoute).toEqual('/')
   })
 })

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -84,4 +84,14 @@ describe('Creating Matcher', function () {
     const { params } = match({ path: '/not-found' }, routes[0])
     expect(params).toEqual({ pathMatch: '/not-found' })
   })
+
+  it('calculates correctly and without warning the path of a partial asterisk route with a default param name and pathMatch empty string', function () {
+    process.env.NODE_ENV = 'development'
+    const { path } = match(
+      { name: 'error', params: { pathMatch: '' }},
+      routes[0]
+    )
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(path).toEqual('/error/')
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->