### PR TITLE
feat(history): Remove event listeners when all apps are destroyed.

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -1,6 +1,30 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 
+// track number of popstate listeners
+// This should be replaced with something better
+let numPopstateListeners = 0
+const listenerCountDiv = document.createElement('div')
+listenerCountDiv.textContent = numPopstateListeners + ' popstate listeners'
+document.body.appendChild(listenerCountDiv)
+
+const originalAddEventListener = window.addEventListener
+const originalRemoveEventListener = window.removeEventListener
+window.addEventListener = function (name, handler) {
+  if (name === 'popstate') {
+    listenerCountDiv.textContent =
+      ++numPopstateListeners + ' popstate listeners'
+  }
+  return originalAddEventListener.apply(this, arguments)
+}
+window.removeEventListener = function (name, handler) {
+  if (name === 'popstate') {
+    listenerCountDiv.textContent =
+      --numPopstateListeners + ' popstate listeners'
+  }
+  return originalRemoveEventListener.apply(this, arguments)
+}
+
 // 1. Use plugin.
 // This installs <router-view> and <router-link>,
 // and injects $router and $route to all router-enabled child components
@@ -55,6 +79,7 @@ new Vue({
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
       <router-view class="view"></router-view>
+      <button v-on:click="teardown">Teardown app</button>
     </div>
   `,
 
@@ -66,6 +91,10 @@ new Vue({
       } else {
         this.$router.push('/', increment)
       }
+    },
+    teardown () {
+      this.$destroy()
+      this.$el.innerHTML = ''
     }
   }
 }).$mount('#app')

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -2,9 +2,9 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 
 // track number of popstate listeners
-// This should be replaced with something better
 let numPopstateListeners = 0
 const listenerCountDiv = document.createElement('div')
+listenerCountDiv.id = 'popstate-count'
 listenerCountDiv.textContent = numPopstateListeners + ' popstate listeners'
 document.body.appendChild(listenerCountDiv)
 
@@ -79,7 +79,7 @@ new Vue({
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
       <router-view class="view"></router-view>
-      <button v-on:click="teardown">Teardown app</button>
+      <button id="teardown-app" v-on:click="teardown">Teardown app</button>
     </div>
   `,
 

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -51,7 +51,7 @@ const router = new VueRouter({
 // 4. Create and mount root instance.
 // Make sure to inject the router.
 // Route components will be rendered inside <router-view>.
-new Vue({
+const vueInstance = new Vue({
   router,
   data: () => ({ n: 0 }),
   template: `
@@ -79,7 +79,6 @@ new Vue({
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
       <router-view class="view"></router-view>
-      <button id="teardown-app" v-on:click="teardown">Teardown app</button>
     </div>
   `,
 
@@ -91,10 +90,11 @@ new Vue({
       } else {
         this.$router.push('/', increment)
       }
-    },
-    teardown () {
-      this.$destroy()
-      this.$el.innerHTML = ''
     }
   }
 }).$mount('#app')
+
+document.getElementById('unmount').addEventListener('click', () => {
+  vueInstance.$destroy()
+  vueInstance.$el.innerHTML = ''
+})

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <link rel="stylesheet" href="/global.css">
 <a href="/">&larr; Examples index</a>
+<button id="unmount">Unmount</button>
+<hr />
 <div id="app"></div>
 <script src="/__build__/shared.chunk.js"></script>
 <script src="/__build__/basic.js"></script>

--- a/examples/hash-mode/app.js
+++ b/examples/hash-mode/app.js
@@ -52,7 +52,7 @@ const router = new VueRouter({
 // 4. Create and mount root instance.
 // Make sure to inject the router.
 // Route components will be rendered inside <router-view>.
-new Vue({
+const vueInstance = new Vue({
   router,
   template: `
     <div id="app">
@@ -70,13 +70,13 @@ new Vue({
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
       <router-view class="view"></router-view>
-      <button id="teardown-app" v-on:click="teardown">Teardown app</button>
     </div>
   `,
   methods: {
-    teardown () {
-      this.$destroy()
-      this.$el.innerHTML = ''
-    }
   }
 }).$mount('#app')
+
+document.getElementById('unmount').addEventListener('click', () => {
+  vueInstance.$destroy()
+  vueInstance.$el.innerHTML = ''
+})

--- a/examples/hash-mode/app.js
+++ b/examples/hash-mode/app.js
@@ -2,9 +2,9 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 
 // track number of popstate listeners
-// This should be replaced with something better
 let numPopstateListeners = 0
 const listenerCountDiv = document.createElement('div')
+listenerCountDiv.id = 'popstate-count'
 listenerCountDiv.textContent = numPopstateListeners + ' popstate listeners'
 document.body.appendChild(listenerCountDiv)
 
@@ -70,7 +70,7 @@ new Vue({
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
       <router-view class="view"></router-view>
-      <button v-on:click="teardown">Teardown app</button>
+      <button id="teardown-app" v-on:click="teardown">Teardown app</button>
     </div>
   `,
   methods: {

--- a/examples/hash-mode/app.js
+++ b/examples/hash-mode/app.js
@@ -1,6 +1,30 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 
+// track number of popstate listeners
+// This should be replaced with something better
+let numPopstateListeners = 0
+const listenerCountDiv = document.createElement('div')
+listenerCountDiv.textContent = numPopstateListeners + ' popstate listeners'
+document.body.appendChild(listenerCountDiv)
+
+const originalAddEventListener = window.addEventListener
+const originalRemoveEventListener = window.removeEventListener
+window.addEventListener = function (name, handler) {
+  if (name === 'popstate') {
+    listenerCountDiv.textContent =
+      ++numPopstateListeners + ' popstate listeners'
+  }
+  return originalAddEventListener.apply(this, arguments)
+}
+window.removeEventListener = function (name, handler) {
+  if (name === 'popstate') {
+    listenerCountDiv.textContent =
+      --numPopstateListeners + ' popstate listeners'
+  }
+  return originalRemoveEventListener.apply(this, arguments)
+}
+
 // 1. Use plugin.
 // This installs <router-view> and <router-link>,
 // and injects $router and $route to all router-enabled child components
@@ -46,6 +70,13 @@ new Vue({
       <pre id="query-t">{{ $route.query.t }}</pre>
       <pre id="hash">{{ $route.hash }}</pre>
       <router-view class="view"></router-view>
+      <button v-on:click="teardown">Teardown app</button>
     </div>
-  `
+  `,
+  methods: {
+    teardown () {
+      this.$destroy()
+      this.$el.innerHTML = ''
+    }
+  }
 }).$mount('#app')

--- a/examples/hash-mode/index.html
+++ b/examples/hash-mode/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <link rel="stylesheet" href="/global.css">
 <a href="/">&larr; Examples index</a>
+<button id="unmount">Unmount</button>
+<hr />
 <div id="app"></div>
 <script src="/__build__/shared.chunk.js"></script>
 <script src="/__build__/hash-mode.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -27,6 +27,7 @@
     <li><a href="discrete-components">Discrete Components</a></li>
     <li><a href="nested-router">Nested Routers</a></li>
     <li><a href="keepalive-view">Keepalive View</a></li>
+    <li><a href="multi-app">Multiple Apps</a></li>
   </ul>
 </body>
 </html>

--- a/examples/multi-app/app.js
+++ b/examples/multi-app/app.js
@@ -1,0 +1,76 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+// track number of popstate listeners
+let numPopstateListeners = 0
+const listenerCountDiv = document.getElementById('popcount')
+listenerCountDiv.textContent = 0
+
+const originalAddEventListener = window.addEventListener
+const originalRemoveEventListener = window.removeEventListener
+window.addEventListener = function (name, handler) {
+  if (name === 'popstate') {
+    listenerCountDiv.textContent =
+      ++numPopstateListeners
+  }
+  return originalAddEventListener.apply(this, arguments)
+}
+window.removeEventListener = function (name, handler) {
+  if (name === 'popstate') {
+    listenerCountDiv.textContent =
+      --numPopstateListeners
+  }
+  return originalRemoveEventListener.apply(this, arguments)
+}
+
+// 1. Use plugin.
+// This installs <router-view> and <router-link>,
+// and injects $router and $route to all router-enabled child components
+Vue.use(VueRouter)
+
+const looper = [1, 2, 3]
+
+looper.forEach((n) => {
+  const mountEl = document.getElementById('mount' + n)
+
+  mountEl.addEventListener('click', () => {
+    // 2. Define route components
+    const Home = { template: '<div>home</div>' }
+    const Foo = { template: '<div>foo</div>' }
+
+    // 3. Create the router
+    const router = new VueRouter({
+      mode: 'history',
+      base: __dirname,
+      routes: [
+        { path: '/', component: Home },
+        { path: '/foo', component: Foo }
+      ]
+    })
+
+    // 4. Create and mount root instance.
+    // Make sure to inject the router.
+    // Route components will be rendered inside <router-view>.
+    new Vue({
+      router,
+      template: `
+        <div id="app-${n}">
+          <h1>Basic</h1>
+          <ul>
+            <li><router-link to="/">/</router-link></li>
+            <li><router-link to="/foo">/foo</router-link></li>
+          </ul>
+          <router-view class="view"></router-view>
+          <button id="unmount${n}" v-on:click="teardown">Teardown app</button>
+        </div>
+      `,
+
+      methods: {
+        teardown () {
+          this.$destroy()
+          this.$el.innerHTML = ''
+        }
+      }
+    }).$mount('#app-' + n)
+  })
+})

--- a/examples/multi-app/app.js
+++ b/examples/multi-app/app.js
@@ -31,7 +31,9 @@ Vue.use(VueRouter)
 const looper = [1, 2, 3]
 
 looper.forEach((n) => {
+  let vueInstance
   const mountEl = document.getElementById('mount' + n)
+  const unmountEl = document.getElementById('unmount' + n)
 
   mountEl.addEventListener('click', () => {
     // 2. Define route components
@@ -51,7 +53,7 @@ looper.forEach((n) => {
     // 4. Create and mount root instance.
     // Make sure to inject the router.
     // Route components will be rendered inside <router-view>.
-    new Vue({
+    vueInstance = new Vue({
       router,
       template: `
         <div id="app-${n}">
@@ -61,16 +63,13 @@ looper.forEach((n) => {
             <li><router-link to="/foo">/foo</router-link></li>
           </ul>
           <router-view class="view"></router-view>
-          <button id="unmount${n}" v-on:click="teardown">Teardown app</button>
         </div>
-      `,
-
-      methods: {
-        teardown () {
-          this.$destroy()
-          this.$el.innerHTML = ''
-        }
-      }
+      `
     }).$mount('#app-' + n)
+  })
+
+  unmountEl.addEventListener('click', () => {
+    vueInstance.$destroy()
+    vueInstance.$el.innerHTML = ''
   })
 })

--- a/examples/multi-app/index.html
+++ b/examples/multi-app/index.html
@@ -8,6 +8,12 @@
 
 <hr />
 
+<button id="unmount1">Unmount App 1</button>
+<button id="unmount2">Unmount App 2</button>
+<button id="unmount3">Unmount App 3</button>
+
+<hr />
+
 popstate count: <span id="popcount"></span>
 
 <div id="app-1"></div>

--- a/examples/multi-app/index.html
+++ b/examples/multi-app/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/global.css">
+<a href="/">&larr; Examples index</a>
+
+<button id="mount1">Mount App 1</button>
+<button id="mount2">Mount App 2</button>
+<button id="mount3">Mount App 3</button>
+
+<hr />
+
+popstate count: <span id="popcount"></span>
+
+<div id="app-1"></div>
+<div id="app-2"></div>
+<div id="app-3"></div>
+
+<script src="/__build__/shared.chunk.js"></script>
+<script src="/__build__/multi-app.js"></script>

--- a/src/history/base.js
+++ b/src/history/base.js
@@ -23,6 +23,8 @@ export class History {
   readyCbs: Array<Function>
   readyErrorCbs: Array<Function>
   errorCbs: Array<Function>
+  listeners: Array<Function>
+  cleanupListeners: Function
 
   // implemented by sub-classes
   +go: (n: number) => void
@@ -30,6 +32,7 @@ export class History {
   +replace: (loc: RawLocation) => void
   +ensureURL: (push?: boolean) => void
   +getCurrentLocation: () => string
+  +setupListeners: Function
 
   constructor (router: Router, base: ?string) {
     this.router = router
@@ -41,6 +44,7 @@ export class History {
     this.readyCbs = []
     this.readyErrorCbs = []
     this.errorCbs = []
+    this.listeners = []
   }
 
   listen (cb: Function) {
@@ -207,6 +211,17 @@ export class History {
     this.router.afterHooks.forEach(hook => {
       hook && hook(route, prev)
     })
+  }
+
+  setupListeners () {
+    // Default implementation is empty
+  }
+
+  teardownListeners () {
+    this.listeners.forEach(cleanupListener => {
+      cleanupListener()
+    })
+    this.listeners = []
   }
 }
 

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -30,9 +30,6 @@ export class HTML5History extends History {
     }
 
     const handleRoutingEvent = () => {
-      const expectScroll = router.options.scrollBehavior
-      const supportsScroll = supportsPushState && expectScroll
-
       const current = this.current
 
       // Avoiding first `popstate` event dispatched in some browsers but first

--- a/src/history/html5.js
+++ b/src/history/html5.js
@@ -8,12 +8,12 @@ import { setupScroll, handleScroll } from '../util/scroll'
 import { pushState, replaceState, supportsPushState } from '../util/push-state'
 
 export class HTML5History extends History {
-  +initLocation: string
+  _startLocation: string
 
   constructor (router: Router, base: ?string) {
     super(router, base)
 
-    this.initLocation = getLocation(this.base)
+    this._startLocation = getLocation(this.base)
   }
 
   setupListeners () {
@@ -38,7 +38,7 @@ export class HTML5History extends History {
       // Avoiding first `popstate` event dispatched in some browsers but first
       // history route not updated since async guard at the same time.
       const location = getLocation(this.base)
-      if (this.current === START && location === this.initLocation) {
+      if (this.current === START && location === this._startLocation) {
         return
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -116,10 +116,12 @@ export default class VueRouter {
 
     const history = this.history
 
-    const setupListeners = () => {
-      history.setupListeners()
+    if (history instanceof HTML5History || history instanceof HashHistory) {
+      const setupListeners = () => {
+        history.setupListeners()
+      }
+      history.transitionTo(history.getCurrentLocation(), setupListeners, setupListeners)
     }
-    history.transitionTo(history.getCurrentLocation(), setupListeners, setupListeners)
 
     history.listen(route => {
       this.apps.forEach((app) => {

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,12 @@ export default class VueRouter {
       // ensure we still have a main app or null if no apps
       // we do not release the router so it can be reused
       if (this.app === app) this.app = this.apps[0] || null
+
+      if (this.apps.length === 0) {
+        // clean up event listeners
+        // https://github.com/vuejs/vue-router/issues/2341
+        this.history.teardownListeners()
+      }
     })
 
     // main app previously initialized
@@ -110,18 +116,10 @@ export default class VueRouter {
 
     const history = this.history
 
-    if (history instanceof HTML5History) {
-      history.transitionTo(history.getCurrentLocation())
-    } else if (history instanceof HashHistory) {
-      const setupHashListener = () => {
-        history.setupListeners()
-      }
-      history.transitionTo(
-        history.getCurrentLocation(),
-        setupHashListener,
-        setupHashListener
-      )
+    const setupListeners = () => {
+      history.setupListeners()
     }
+    history.transitionTo(history.getCurrentLocation(), setupListeners, setupListeners)
 
     history.listen(route => {
       this.apps.forEach((app) => {

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ export default class VueRouter {
       // we do not release the router so it can be reused
       if (this.app === app) this.app = this.apps[0] || null
 
-      if (this.apps.length === 0) {
+      if (!this.app) {
         // clean up event listeners
         // https://github.com/vuejs/vue-router/issues/2341
         this.history.teardownListeners()

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -19,12 +19,10 @@ export function setupScroll () {
   const stateCopy = extend({}, window.history.state)
   stateCopy.key = getStateKey()
   window.history.replaceState(stateCopy, '', absolutePath)
-  window.addEventListener('popstate', e => {
-    saveScrollPosition()
-    if (e.state && e.state.key) {
-      setStateKey(e.state.key)
-    }
-  })
+  window.addEventListener('popstate', handlePopState)
+  return () => {
+    window.removeEventListener('popstate', handlePopState)
+  }
 }
 
 export function handleScroll (
@@ -83,6 +81,13 @@ export function saveScrollPosition () {
       x: window.pageXOffset,
       y: window.pageYOffset
     }
+  }
+}
+
+function handlePopState (e) {
+  saveScrollPosition()
+  if (e.state && e.state.key) {
+    setStateKey(e.state.key)
   }
 }
 

--- a/test/e2e/specs/basic.js
+++ b/test/e2e/specs/basic.js
@@ -70,6 +70,11 @@ module.exports = {
       .assert.cssClassPresent('li:nth-child(8)', 'exact-active')
       .assert.attributeEquals('li:nth-child(8) a', 'class', '')
 
+      // Listener cleanup
+      .assert.containsText('#popstate-count', '1 popstate listeners')
+      .click('#teardown-app')
+      .assert.containsText('#popstate-count', '0 popstate listeners')
+
       .end()
   }
 }

--- a/test/e2e/specs/basic.js
+++ b/test/e2e/specs/basic.js
@@ -72,7 +72,7 @@ module.exports = {
 
       // Listener cleanup
       .assert.containsText('#popstate-count', '1 popstate listeners')
-      .click('#teardown-app')
+      .click('#unmount')
       .assert.containsText('#popstate-count', '0 popstate listeners')
 
       .end()

--- a/test/e2e/specs/hash-mode.js
+++ b/test/e2e/specs/hash-mode.js
@@ -60,7 +60,7 @@ module.exports = {
 
       // Listener cleanup
       .assert.containsText('#popstate-count', '1 popstate listeners')
-      .click('#teardown-app')
+      .click('#unmount')
       .assert.containsText('#popstate-count', '0 popstate listeners')
 
       .end()

--- a/test/e2e/specs/hash-mode.js
+++ b/test/e2e/specs/hash-mode.js
@@ -57,6 +57,12 @@ module.exports = {
       .waitForElementVisible('#app', 1000)
       .assert.containsText('.view', 'unicode: ñ')
       .assert.containsText('#query-t', '%')
+
+      // Listener cleanup
+      .assert.containsText('#popstate-count', '1 popstate listeners')
+      .click('#teardown-app')
+      .assert.containsText('#popstate-count', '0 popstate listeners')
+
       .end()
   }
 }

--- a/test/e2e/specs/multi-app.js
+++ b/test/e2e/specs/multi-app.js
@@ -1,0 +1,49 @@
+const bsStatus = require('../browserstack-send-status')
+
+module.exports = {
+  ...bsStatus(),
+
+  '@tags': ['history'],
+
+  basic: function (browser) {
+    browser
+      .url('http://localhost:8080/multi-app/')
+      .waitForElementVisible('#mount1', 1000)
+      .assert.containsText('#popcount', '0')
+      .click('#mount1')
+      .waitForElementVisible('#app-1 > *', 1000)
+      .assert.containsText('#popcount', '1')
+      .click('#mount2')
+      .waitForElementVisible('#app-2 > *', 1000)
+      .assert.containsText('#popcount', '2')
+      .click('#mount3')
+      .waitForElementVisible('#app-3 > *', 1000)
+      .assert.containsText('#popcount', '3')
+
+      // They should all be displaying the home page
+      .assert.containsText('#app-1', 'home')
+      .assert.containsText('#app-2', 'home')
+      .assert.containsText('#app-3', 'home')
+
+      // Navigate to foo route
+      .click('#app-1 li:nth-child(2) a')
+      .assert.containsText('#app-1', 'foo')
+
+      .click('#app-2 li:nth-child(2) a')
+      .assert.containsText('#app-2', 'foo')
+
+      .click('#app-3 li:nth-child(2) a')
+      .assert.containsText('#app-3', 'foo')
+
+      // Unmount all apps
+      .assert.containsText('#popcount', '3')
+      .click('#unmount1')
+      .assert.containsText('#popcount', '2')
+      .click('#unmount2')
+      .assert.containsText('#popcount', '1')
+      .click('#unmount3')
+      .assert.containsText('#popcount', '0')
+
+      .end()
+  }
+}


### PR DESCRIPTION
This resolves #3152 and resolves #2341

This is my first PR to vue-router and I am not sure if this was the best approach to solving the problem - please let me know! I also need to think of a good way of testing this behavior in either the e2e or unit tests. The unit tests only use the the abstract mode, but the feature only applies to html5/hash modes. And for e2e tests, I need to brainstorm the best way to verify that the hashchange and popstate listeners are being removed.