### PR TITLE
fix(import): avoid installing on global Vue if present on window

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,3 @@ function createHref (base: string, fullPath: string, mode) {
 
 VueRouter.install = install
 VueRouter.version = '__VERSION__'
-
-if (inBrowser && window.Vue) {
-  window.Vue.use(VueRouter)
-}


### PR DESCRIPTION
Proposal to avoid installing vue-router on global window.Vue.

VueRouter should probably not make the assumption that if Vue is globally available (window), it should be installed on it. In some contexts, it's undesirable.

For example, as a developer of plugins for a given product, I want to isolate as much as possible my plugin from the other plugins available at runtime. That's why I ship my product embedding my own Vue & VueRouter instance (not provided by the hosting product) and I don't expose it globally. However, I have no guarantee that other plugins will take the same precaution... In that case, VueRouter will install itself in both and will result in undesired errors/warnings (required prop "to" not defined on router-link component for example).

Vue proposes to install plugin through Vue.use, so, we should let the VueRouter consumer deciding on which Vue instance he wants to install it, no ?
