### PR TITLE
feat(matcher): Adds matchAll to Matcher

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,14 @@ export default class VueRouter {
     return this.matcher.match(raw, current, redirectedFrom)
   }
 
+  matchAll (
+    raw: RawLocation,
+    current?: Route,
+    redirectedFrom?: Location
+  ): Array<Route> {
+    return this.matcher.matchAll(raw, current, redirectedFrom)
+  }
+
   get currentRoute (): ?Route {
     return this.history && this.history.current
   }


### PR DESCRIPTION
There are cases in which different routes can be matched in runtime (eg: dynamic importing a module within a component). Adding a `matchAll` method helps developers create a fallback strategy for those special cases.