### PR TITLE
refactor(scroll-behavior): clean up scroll-behavior tests

### DIFF
--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -33,12 +33,8 @@ module.exports = {
         null,
         'restore scroll position on back'
       )
-
-      // with manual scroll restoration
-      // https://developers.google.com/web/updates/2015/09/history-api-scroll-restoration
       .execute(function () {
         window.scrollTo(0, 100)
-        history.scrollRestoration = 'manual'
       })
       .click('li:nth-child(2) a')
       .waitForElementPresent('.view.foo', TIMEOUT)
@@ -97,7 +93,6 @@ module.exports = {
         null,
         'scroll to top on new entry'
       )
-
       .click('li:nth-child(4) a')
       .assert.evaluate(
         function () {
@@ -106,10 +101,7 @@ module.exports = {
         null,
         'scroll to anchor'
       )
-
-      .execute(function () {
-        document.querySelector('li:nth-child(5) a').click()
-      })
+      .click('li:nth-child(5) a')
       .assert.evaluate(
         function () {
           return document.getElementById('anchor2').getBoundingClientRect().top < 101
@@ -117,9 +109,7 @@ module.exports = {
         null,
         'scroll to anchor with offset'
       )
-      .execute(function () {
-        document.querySelector('li:nth-child(6) a').click()
-      })
+      .click('li:nth-child(6) a')
       .assert.evaluate(
         function () {
           return document.getElementById('1number').getBoundingClientRect().top < 1

--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -93,6 +93,7 @@ module.exports = {
         null,
         'scroll to top on new entry'
       )
+
       .click('li:nth-child(4) a')
       .assert.evaluate(
         function () {

--- a/test/e2e/specs/scroll-behavior.js
+++ b/test/e2e/specs/scroll-behavior.js
@@ -102,6 +102,7 @@ module.exports = {
         null,
         'scroll to anchor'
       )
+
       .click('li:nth-child(5) a')
       .assert.evaluate(
         function () {


### PR DESCRIPTION
Cleaned up scroll-behavior tests while working on #3199 

- `history.scrollRestoration = 'manual'` is no longer needed with #1814 
- replaced some `execute` functions that can be replaced with `click`