### PR TITLE
fix(errors): NavigationCanceled with async components

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -200,7 +200,7 @@ export class History {
       const queue = enterGuards.concat(this.router.resolveHooks)
       runQueue(queue, iterator, () => {
         if (this.pending !== route) {
-          return abort()
+          return abort(createNavigationCancelledError(current, route))
         }
         this.pending = null
         onComplete(route)

--- a/test/unit/specs/error-handling.spec.js
+++ b/test/unit/specs/error-handling.spec.js
@@ -9,7 +9,7 @@ describe('error handling', () => {
     const router = new VueRouter()
     const err = new Error('foo')
     router.beforeEach(() => { throw err })
-    router.onError(() => {})
+    router.onError(() => { })
 
     const onReady = jasmine.createSpy('ready')
     const onError = jasmine.createSpy('error')
@@ -65,6 +65,26 @@ describe('error handling', () => {
     router.push('/')
   })
 
+  it('NavigationCancelled error for nested async navigation', (done) => {
+    const component = {
+      template: `<img />`,
+      beforeRouteEnter (to, from, next) {
+        setTimeout(() => next(), 100)
+      }
+    }
+    const router = new VueRouter({
+      routes: [
+        { path: '/a', component }
+      ]
+    })
+
+    router.push('/a').catch(err => {
+      expect(err.type).toBe(NavigationFailureType.cancelled)
+      done()
+    })
+    router.push('/')
+  })
+
   it('NavigationRedirected error', done => {
     const router = new VueRouter()
 
@@ -105,7 +125,7 @@ describe('error handling', () => {
     })
 
     router.onError(spy1)
-    router.onReady(() => {}, spy2)
+    router.onReady(() => { }, spy2)
 
     router.push('/').catch(spy3).finally(() => {
       expect(spy1).toHaveBeenCalledWith(err)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Canceled behavior should always throw a same canceled error, instead of `undefined`

Same as these codes:

https://github.com/vuejs/vue-router/blob/c8a4cefcb1a570245040e80bbec20cfe476a1c85/src/history/base.js#L160-L162


Related PR:

- https://github.com/vuejs/vue-router/pull/3047