### PR TITLE
fix: error.stack is possibly null

### DIFF
--- a/src/history/errors.js
+++ b/src/history/errors.js
@@ -48,9 +48,12 @@ function createRouterError (from, to, type, message) {
   error.to = to
   error.type = type
 
-  const newStack = error.stack.split('\n')
-  newStack.splice(1, 2) // remove 2 last useless calls
-  error.stack = newStack.join('\n')
+  if (typeof error.stack === 'string') {
+    const newStack = error.stack.split('\n')
+    newStack.splice(1, 2) // remove 2 last useless calls
+    error.stack = newStack.join('\n')
+  }
+
   return error
 }
 

--- a/src/history/errors.js
+++ b/src/history/errors.js
@@ -48,12 +48,6 @@ function createRouterError (from, to, type, message) {
   error.to = to
   error.type = type
 
-  if (typeof error.stack === 'string') {
-    const newStack = error.stack.split('\n')
-    newStack.splice(1, 2) // remove 2 last useless calls
-    error.stack = newStack.join('\n')
-  }
-
   return error
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

In unsupported `Error.stack` browsers, that throws `TypeError(Unable to get property 'split' of undefined or null reference)`.
