### PR TITLE
docs: Update Caddy example

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -97,7 +97,13 @@ For Node.js/Express, consider using [connect-history-api-fallback middleware](ht
 </configuration>
 ```
 
-#### Caddy
+#### Caddy v2
+
+```
+try_files {path} /
+```
+
+#### Caddy v1
 
 ```
 rewrite {


### PR DESCRIPTION
Caddy v2 was released recently. This updates the https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations page with an example that will work for Caddy v2, and adds the `v1` suffix for the old example.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
