### PR TITLE
feat(types): RouterConfig for multiple components (#3217)

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -94,7 +94,6 @@ interface _RouteConfigBase {
   name?: string
   redirect?: RedirectOption
   alias?: string | string[]
-  children?: RouteConfig[]
   meta?: any
   beforeEnter?: NavigationGuard
   caseSensitive?: boolean
@@ -108,6 +107,7 @@ interface RouteConfigSingleView extends _RouteConfigBase {
 
 interface RouteConfigMultipleViews extends _RouteConfigBase {
   components?: Dictionary<Component>
+  children?: RouteConfig[]
   props?: Dictionary<boolean | Object | RoutePropsFunction>
 }
 

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -89,20 +89,29 @@ export interface PathToRegexpOptions {
   end?: boolean
 }
 
-export interface RouteConfig {
+interface _RouteConfigBase {
   path: string
   name?: string
-  component?: Component
-  components?: Dictionary<Component>
   redirect?: RedirectOption
   alias?: string | string[]
   children?: RouteConfig[]
   meta?: any
   beforeEnter?: NavigationGuard
-  props?: boolean | Object | RoutePropsFunction
   caseSensitive?: boolean
   pathToRegexpOptions?: PathToRegexpOptions
 }
+
+interface RouteConfigSingleView extends _RouteConfigBase {
+  component?: Component
+  props?: boolean | Object | RoutePropsFunction
+}
+
+interface RouteConfigMultipleViews extends _RouteConfigBase {
+  components?: Dictionary<Component>
+  props?: Dictionary<boolean | Object | RoutePropsFunction>
+}
+
+export type RouteConfig = RouteConfigSingleView | RouteConfigMultipleViews
 
 export interface RouteRecord {
   path: string

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -8,6 +8,7 @@ Vue.use(VueRouter)
 const Home = { template: '<div>home</div>' }
 const Foo = { template: '<div>foo</div>' }
 const Bar = { template: '<div>bar</div>' }
+const Abc = { template: '<div>abc</div>' }
 const Async = () => Promise.resolve({ template: '<div>async</div>' })
 
 const Hook: ComponentOptions<Vue> = {
@@ -76,6 +77,7 @@ const router = new VueRouter({
           components: {
             default: Foo,
             bar: Bar,
+            abc: Abc,
             asyncComponent: Async
           },
           meta: { auth: true },
@@ -88,6 +90,7 @@ const router = new VueRouter({
           props: {
             default: true,
             bar: { id: 123 },
+            abc: route => route.params,
             asyncComponent: (route: Route) => route.params
           }
         },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Closes #3217

The test demonstrates that with correct typings, typescript is able to infer that route is of type `Route` on its own.
```
             abc: route => route.params,
```