### PR TITLE
fix(query): Fix query props should be casted into string (fix #2131)

### DIFF
--- a/src/util/query.js
+++ b/src/util/query.js
@@ -29,7 +29,8 @@ export function resolveQuery (
     parsedQuery = {}
   }
   for (const key in extraQuery) {
-    parsedQuery[key] = extraQuery[key].toString()
+    const value = extraQuery[key]
+    parsedQuery[key] = Array.isArray(value) ? value.map(v => '' + v) : '' + value
   }
   return parsedQuery
 }

--- a/src/util/query.js
+++ b/src/util/query.js
@@ -29,7 +29,7 @@ export function resolveQuery (
     parsedQuery = {}
   }
   for (const key in extraQuery) {
-    parsedQuery[key] = extraQuery[key]
+    parsedQuery[key] = extraQuery[key].toString()
   }
   return parsedQuery
 }

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -24,7 +24,6 @@ describe('Query utils', () => {
       const query = resolveQuery('foo=bar&foo=k', { baz: 1 })
       expect(query.baz).toBe('1')
     })
-    
     it('should cast query array values into string', () => {
       const query = resolveQuery('foo=bar&foo=k', { baz: [1, '2'] })
       expect(query.baz).toEqual(['1', '2'])

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -19,6 +19,11 @@ describe('Query utils', () => {
         arr: ['1', null, '2']
       })
     })
+
+    it('should cast query props into string', () => {
+      const query = resolveQuery('foo=bar&foo=k', { baz: 1 })
+      expect(typeof query.baz).toBe('string')
+    })
   })
 
   describe('stringifyQuery', () => {

--- a/test/unit/specs/query.spec.js
+++ b/test/unit/specs/query.spec.js
@@ -20,9 +20,14 @@ describe('Query utils', () => {
       })
     })
 
-    it('should cast query props into string', () => {
+    it('should cast query values into string', () => {
       const query = resolveQuery('foo=bar&foo=k', { baz: 1 })
-      expect(typeof query.baz).toBe('string')
+      expect(query.baz).toBe('1')
+    })
+    
+    it('should cast query array values into string', () => {
+      const query = resolveQuery('foo=bar&foo=k', { baz: [1, '2'] })
+      expect(query.baz).toEqual(['1', '2'])
     })
   })
 


### PR DESCRIPTION
Greetings,
This PR is for fixing [#2131]('https://github.com/vuejs/vue-router/issues/2131')

### What I've added?
query props now is casted into String,  applying stringify on programmatic navigation (next, this.$router.push etc.)

Closes #2131

Thanks