### PR TITLE
fix(types): add missing `options` property type

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -21,6 +21,7 @@ export declare class VueRouter {
   constructor(options?: RouterOptions)
 
   app: Vue
+  options: RouterOptions;
   mode: RouterMode
   currentRoute: Route
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

See [VueRouter.prototype.options](https://github.com/vuejs/vue-router/blob/dev/src/index.js#L27)