### PR TITLE
fix: Adjust router.go to fire navigation guards

### DIFF
--- a/src/history/abstract.js
+++ b/src/history/abstract.js
@@ -44,11 +44,10 @@ export class AbstractHistory extends History {
       return
     }
     const route = this.stack[targetIndex]
-    this.confirmTransition(
-      route,
+    this.transitionTo(
+      route.fullPath,
       () => {
         this.index = targetIndex
-        this.updateRoute(route)
       },
       err => {
         if (isRouterError(err, NavigationFailureType.duplicated)) {


### PR DESCRIPTION
Adjust router.go to fire navigation guards when using abstract routing mode.

Close #3250 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
