### PR TITLE
fix(create-mathcer): remove duplicated decodeURIComponent

### DIFF
--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -185,10 +185,9 @@ function matchRoute (
 
   for (let i = 1, len = m.length; i < len; ++i) {
     const key = regex.keys[i - 1]
-    const val = typeof m[i] === 'string' ? decodeURIComponent(m[i]) : m[i]
     if (key) {
       // Fix #1994: using * with props: true generates a param named 0
-      params[key.name || 'pathMatch'] = val
+      params[key.name || 'pathMatch'] = m[i]
     }
   }
 


### PR DESCRIPTION
So, checking this issue https://github.com/vuejs/vue-router/issues/2725
I found that removing the `decodeURIComponent` from the `matchRoute` kinda resolve the problem, because the param already comes decoded.

I don't know if this is the proper way to fix this issue, but I will give some examples below that worked for me:

**URL**: _/route-matching/params/%252520-working/bar_  

PS*: Check the `foo` param

**Without the fix**  :
![FAIL-route-matching_params_%252520-working_bar](https://user-images.githubusercontent.com/20761700/88710319-df927c80-d0ec-11ea-8178-99faebc41b7f.png)


**After the change:**
![WORK-route-matching_params_%252520-working_bar](https://user-images.githubusercontent.com/20761700/88710389-f933c400-d0ec-11ea-8eaa-4c136c28a4ba.png)


This example was also broking:
**URL**: /route-matching/params/100%25-working/bar"

![FAIL-route-matching_params_100%25-working_bar](https://user-images.githubusercontent.com/20761700/88710658-53348980-d0ed-11ea-9468-75e5370b4c4f.png)

Closes #2725 
Closes #3138
