### PR TITLE
Allow objects to be passed in as params in Location

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -163,7 +163,7 @@ export interface Location {
   path?: string
   hash?: string
   query?: Dictionary<string | (string | null)[] | null | undefined>
-  params?: Dictionary<string>
+  params?: Dictionary<string | Object>
   append?: boolean
   replace?: boolean
 }


### PR DESCRIPTION
Objects can be passed on as parameters to `this.$router.push(Location)`. This PR prevents linter from emitting errors.