### PR TITLE
fix(encoding): decode params

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -45,7 +45,7 @@ const router = new VueRouter({
     { path: '/', component: Home },
     { path: '/foo', component: Foo },
     { path: '/bar', component: Bar },
-    { path: '/é', component: Unicode },
+    { path: encodeURI('/é'), component: Unicode },
     { path: '/query/:q', component: Query }
   ]
 })
@@ -76,9 +76,9 @@ const vueInstance = new Vue({
         <router-link tag="li" to="/bar" :event="['mousedown', 'touchstart']">
           <a>/bar</a>
         </router-link>
-        <li><router-link to="/é">/é</router-link></li>
-        <li><router-link to="/é?t=%25ñ">/é?t=%ñ</router-link></li>
-        <li><router-link to="/é#%25ñ">/é#%25ñ</router-link></li>
+        <li><router-link :to="encodeURI('/é')">/é</router-link></li>
+        <li><router-link :to="encodeURI('/é?t=%ñ')">/é?t=%ñ</router-link></li>
+        <li><router-link :to="encodeURI('/é#%ñ')">/é#%25ñ</router-link></li>
         <router-link to="/foo" v-slot="props">
           <li :class="[props.isActive && 'active', props.isExactActive && 'exact-active']">
             <a :href="props.href" @click="props.navigate">{{ props.route.path }} (with v-slot).</a>

--- a/examples/hash-mode/app.js
+++ b/examples/hash-mode/app.js
@@ -45,8 +45,8 @@ const router = new VueRouter({
     { path: '/', component: Home }, // all paths are defined without the hash.
     { path: '/foo', component: Foo },
     { path: '/bar', component: Bar },
-    { path: '/é', component: Unicode },
-    { path: '/é/:unicode', component: Unicode },
+    { path: encodeURI('/é'), component: Unicode },
+    { path: encodeURI('/é/:unicode'), component: Unicode },
     { path: '/query/:q', component: Query, name: 'param' }
   ]
 })
@@ -64,10 +64,10 @@ const vueInstance = new Vue({
         <li><router-link to="/foo">/foo</router-link></li>
         <li><router-link to="/bar">/bar</router-link></li>
         <router-link tag="li" to="/bar">/bar</router-link>
-        <li><router-link to="/é">/é</router-link></li>
-        <li><router-link to="/é/ñ">/é/ñ</router-link></li>
-        <li><router-link to="/é/ñ?t=%25ñ">/é/ñ?t=%ñ</router-link></li>
-        <li><router-link to="/é/ñ#é">/é/ñ#é</router-link></li>
+        <li><router-link :to="encodeURI('/é')">/é</router-link></li>
+        <li><router-link :to="encodeURI('/é/ñ')">/é/ñ</router-link></li>
+        <li><router-link :to="encodeURI('/é/ñ?t=%ñ')">/é/ñ?t=%ñ</router-link></li>
+        <li><router-link :to="encodeURI('/é/ñ#é')">/é/ñ#é</router-link></li>
         <li><router-link to="/query/A%25">/query/A%</router-link></li>
         <li><router-link :to="{ name: 'param', params: { q: 'A%' }}">/query/A% (object)</router-link></li>
         <li><router-link to="/query/A%2FE">/query/A%2FE</router-link></li>

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -7,6 +7,7 @@ import { createRoute } from './util/route'
 import { fillParams } from './util/params'
 import { createRouteMap } from './create-route-map'
 import { normalizeLocation } from './util/location'
+import { decode } from './util/query'
 
 export type Matcher = {
   match: (raw: RawLocation, current?: Route, redirectedFrom?: Location) => Route;
@@ -175,14 +176,6 @@ function matchRoute (
   path: string,
   params: Object
 ): boolean {
-  try {
-    path = decodeURI(path)
-  } catch (err) {
-    if (process.env.NODE_ENV !== 'production') {
-      warn(false, `Error decoding "${path}". Leaving it intact.`)
-    }
-  }
-
   const m = path.match(regex)
 
   if (!m) {
@@ -195,7 +188,7 @@ function matchRoute (
     const key = regex.keys[i - 1]
     if (key) {
       // Fix #1994: using * with props: true generates a param named 0
-      params[key.name || 'pathMatch'] = m[i]
+      params[key.name || 'pathMatch'] = typeof m[i] === 'string' ? decode(m[i]) : m[i]
     }
   }
 

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -70,6 +70,14 @@ function addRouteRecord (
         path || name
       )} cannot be a ` + `string id. Use an actual component instead.`
     )
+
+    warn(
+      // eslint-disable-next-line no-control-regex
+      !/[^\u0000-\u007F]+/.test(path),
+      `Route with path "${path}" contains unencoded characters, make sure ` +
+        `your path is correctly encoded before passing it to the router. Use ` +
+        `encodeURI to encode static segments of your path.`
+    )
   }
 
   const pathToRegexpOptions: PathToRegexpOptions =

--- a/test/unit/specs/create-map.spec.js
+++ b/test/unit/specs/create-map.spec.js
@@ -81,6 +81,15 @@ describe('Creating Route Map', function () {
     )
   })
 
+  it('warns about unencoded entities', function () {
+    process.env.NODE_ENV = 'development'
+    maps = createRouteMap([{ path: '/é', component: Home }])
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn.calls.argsFor(0)[0]).toMatch(
+      'vue-router] Route with path "/é"'
+    )
+  })
+
   it('in development, throws if path is missing', function () {
     process.env.NODE_ENV = 'development'
     expect(() => {


### PR DESCRIPTION
## What is breaking

Users no longer can use unencoded static paths:

- A route defined with `{ path: '/cassé' }`
- `<router-link to="/cassé" />`
- `<router-link :to="{ path '/cassé' }" />`
- `router.push('/cassé')`
- `router.push({ path: '/cassé' })`

They have to manually encode them with `encodeURI()` or use a named route:

```js
new Router({
  routes: [
    { path: '/cassé' },
    // becomes
    { path: encodeURI('/cassé') },
    // be careful to not encode characters used in a regex ([ and ] are encoded by encodeURI)
	{ path: '/色/:hex([0-9a-f]+)' },
    // becomes
    { path: encodeURI('/色') + '/:hex([0-9a-f]+)' },
	// not necessary if all characters are latin
    { path: '/articles/:articleTitle' }
 ]
})
```

```js
router.push('/cassé')
// becomes
router.push(encodeURI('/cassé'))
```

```html
<router-link to="/cassé" />
becomes
<router-link :to="encodeURI('/cassé')" />
or with a name
<router-link :to="{ name: 'cassé' }" />
```

This is **only necessary** with string locations. When using params and query, the behavior is still the same **and using named routes with params** is recommended for that reason:

```js
// given a route /servers/:server
// going to /servers/one%2Ftwo
// should give
this.$route.params.server // one/two
```

In fact, this PR makes this possible, it wasn't working before.

Similarly, doing `router.push({ name: 'servers', params: { server: 'one/two' }})` will change the url to `/servers/one%2Ftwo` while giving the correct value in `$route.params.server`.

## Why this can't be done automatically by the router

We could automatically call `encodeURI()` on each static segment of a path but this would also break code for users who are already correctly encoding `path` (you should always encode URLs, even before this change).

## How to help the migration

Since we were never supposed to pass an unencoded `path` to a route record or even call `router.push()` with an unencoded string or `path` property, I propose to warn in dev mode if any unencoded character is passed to help people be aware of how they should encode their routes.

---


### Internal explanation

Previously, this used to work because we were decoding paths twice, but this created other problems like **errors with URLs containing the character `%` encoded**. By fixing this bug we must remove the `decode` call made on the path when matching against existing routes, but this also makes it **impossible to automatically encode `path` anymore** because the user wouldn't be able to provide encoded characters, e.g. the `/` character (`%2F`) would be transformed to its encoded version, `%252F` (`%` is encoded as `%25`) and there wouldn't be a way to match an encoded slash character which is necessary in segments of the URL since the slash character is used to differentiate segments in a URL. Without this change, we can't correctly decode `%2F`


Overall, this makes things consistent and it's also the same behavior that exists in v4

Close #3337
Close #3103
Close #3125

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
