### PR TITLE
feat(scroll): dd behavior support on scrollBehavior

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -165,7 +165,8 @@ function scrollToPosition (shouldScroll, position) {
       window.scrollTo({
         left: position.x,
         top: position.y,
-        behavior: shouldScroll.behaviour || 'auto'
+        // $flow-disable-line
+        behavior: shouldScroll.behavior
       })
     } else {
       window.scrollTo(position.x, position.y)

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -160,6 +160,15 @@ function scrollToPosition (shouldScroll, position) {
   }
 
   if (position) {
-    window.scrollTo(position.x, position.y)
+    // $flow-disable-line
+    if ('scrollBehavior' in document.documentElement.style) {
+      window.scrollTo({
+        left: position.x,
+        top: position.y,
+        behavior: shouldScroll.behaviour || 'auto'
+      })
+    } else {
+      window.scrollTo(position.x, position.y)
+    }
   }
 }

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -86,7 +86,7 @@ export interface NavigationFailure extends Error {
 }
 
 type Position = { x: number; y: number }
-type PositionResult = Position | { selector: string; offset?: Position } | void
+type PositionResult = Position | { selector: string; offset?: Position, behavior?: ScrollBehavior } | void
 
 export interface RouterOptions {
   routes?: RouteConfig[]


### PR DESCRIPTION
Add the possibility to pass behaviour type to window.scrollTo if supported by browser.

Close #2069

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
