### PR TITLE
docs: navigation-failures.md fix examples

### DIFF
--- a/docs/guide/advanced/navigation-failures.md
+++ b/docs/guide/advanced/navigation-failures.md
@@ -19,8 +19,8 @@ In v3.2.0, _Navigation Failures_ were exposed through the two optional callbacks
 _Navigation Failures_ are `Error` instances with a few extra properties. To check if an error comes from the Router, use the `isNavigationFailure` function:
 
 ```js
-import VueRouter from 'vue-router'
-const { isNavigationFailure, NavigationFailureType } = VueRouter
+import router from 'vue-router'
+const { isNavigationFailure, NavigationFailureType } = router
 
 // trying to access the admin page
 router.push('/admin').catch(failure => {

--- a/docs/ru/guide/advanced/navigation-failures.md
+++ b/docs/ru/guide/advanced/navigation-failures.md
@@ -19,8 +19,8 @@
 _Сбой навигации_ будет экземпляром `Error` с парой дополнительных свойств. Проверить произошла ли ошибка в маршрутизаторе можно с помощью функции `isNavigationFailure`:
 
 ```js
-import VueRouter from 'vue-router'
-const { isNavigationFailure, NavigationFailureType } = VueRouter
+import router from 'vue-router'
+const { isNavigationFailure, NavigationFailureType } = router
 
 // попытка перехода к странице администрирования
 router


### PR DESCRIPTION
Because everywhere on the page used `router` for navigation, which need to be imported as `router`
