### PR TITLE
feat(history): allow full base url

### DIFF
--- a/src/history/base.js
+++ b/src/history/base.js
@@ -274,7 +274,7 @@ function normalizeBase (base: ?string): string {
     }
   }
   // make sure there's the starting slash
-  if (base.charAt(0) !== '/') {
+  if (base.charAt(0) !== '/' && !base.startsWith('http')) {
     base = '/' + base
   }
   // remove trailing slash

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -70,5 +70,11 @@ export function parsePath (path: string): {
 }
 
 export function cleanPath (path: string): string {
-  return path.replace(/\/\//g, '/')
+  let protocol = ''
+  let p = path
+  if (p.startsWith('https://') || p.startsWith('http://')) {
+    protocol = p.startsWith('https://') ? 'https://' : 'http://'
+    p = p.replace(protocol, '')
+  }
+  return protocol + p.replace(/\/\//g, '/')
 }

--- a/test/unit/specs/base-history.spec.js
+++ b/test/unit/specs/base-history.spec.js
@@ -1,0 +1,35 @@
+import { History } from '../../../src/history/base'
+
+describe('Base history', () => {
+  describe('normalizeBase', () => {
+    it('allows full URL', () => {
+      const history = new History(undefined, 'https://somedomain.com/some/path')
+      history.base
+      expect(history.base).toBe('https://somedomain.com/some/path')
+    })
+
+    it('removes trailing slash from full URL', () => {
+      const history = new History(undefined, 'https://somedomain.com/some/path/')
+      history.base
+      expect(history.base).toBe('https://somedomain.com/some/path')
+    })
+
+    it('removes trailing slash from full URL', () => {
+      const history = new History(undefined, 'https://somedomain.com/some/path/')
+      history.base
+      expect(history.base).toBe('https://somedomain.com/some/path')
+    })
+
+    it('prefixes relative urls with a slash', () => {
+      const history = new History(undefined, 'some/path/')
+      history.base
+      expect(history.base).toBe('/some/path')
+    })
+
+    it('defaults to empty string', () => {
+      const history = new History(undefined, undefined)
+      history.base
+      expect(history.base).toBe('')
+    })
+  })
+})

--- a/test/unit/specs/path.spec.js
+++ b/test/unit/specs/path.spec.js
@@ -73,5 +73,15 @@ describe('Path utils', () => {
       const path = cleanPath('//a//b//d/')
       expect(path).toBe('/a/b/d/')
     })
+
+    it('should not replace slashes after https', () => {
+      const path = cleanPath('https://somedomain.com//some//path/')
+      expect(path).toBe('https://somedomain.com/some/path/')
+    })
+
+    it('should not replace slashes after http', () => {
+      const path = cleanPath('http://somedomain.com//some//path/')
+      expect(path).toBe('http://somedomain.com/some/path/')
+    })
   })
 })


### PR DESCRIPTION
I'm working on a project that includes a <base> tag in the HTML so that all static assets are loaded through a CDN on a different domain. When you add a <base> tag, relative paths pushed to the history API use the href of the <base> instead of window.location.host.

In order to not direct the user to the CDN, I'd like to make a change to allow vue-router to accept full URLs. This only requires a minor change to two lines:
1. To ensure that a leading slash is not added before the protocol of a full URL in `normalizeBase`.
2. To keep double slashes after the protocol in `cleanPath`.
