### PR TITLE
Make sure scrollRestoration is writable.

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -10,7 +10,9 @@ const positionStore = Object.create(null)
 export function setupScroll () {
   // Prevent browser scroll behavior on History popstate
   if ('scrollRestoration' in window.history) {
-    window.history.scrollRestoration = 'manual'
+      try {
+        window.history.scrollRestoration = 'manual';
+      } catch () {
   }
   // Fix for #1585 for Firefox
   // Fix for #2195 Add optional third attribute to workaround a bug in safari https://bugs.webkit.org/show_bug.cgi?id=182678


### PR DESCRIPTION
I'm receiving this error
TypeError · Cannot set property scrollRestoration of [object History] which has only a getter

with additional info:
node_modules/vue-router/dist/vue-router.esm.js:1694:39 setupScroll	
function setupScroll () {
  // Prevent browser scroll behavior on History popstate
  if ('scrollRestoration' in window.history) {
    window.history.scrollRestoration = 'manual';
  }

I propose to add this try-catch to verify if scrollRestoration is really writable before trying to set it.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
