### PR TITLE
types: add RouteMeta interface to enable module augmentation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ export default VueRouter
 
 export {
   RouterMode,
+  RouteMeta,
   RawLocation,
   RedirectOption,
   RouterOptions,

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -126,7 +126,7 @@ interface _RouteConfigBase {
   children?: RouteConfig[]
   redirect?: RedirectOption
   alias?: string | string[]
-  meta?: any
+  meta?: RouteMeta
   beforeEnter?: NavigationGuard
   caseSensitive?: boolean
   pathToRegexpOptions?: PathToRegexpOptions
@@ -153,7 +153,7 @@ export interface RouteRecord {
   parent?: RouteRecord
   redirect?: RedirectOption
   matchAs?: string
-  meta: any
+  meta: RouteMeta
   beforeEnter?: (
     route: Route,
     redirect: (location: RawLocation) => void,
@@ -205,5 +205,8 @@ export interface Route {
   fullPath: string
   matched: RouteRecord[]
   redirectedFrom?: string
-  meta?: any
+  meta?: RouteMeta
+}
+
+export interface RouteMeta {
 }

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -208,5 +208,4 @@ export interface Route {
   meta?: RouteMeta
 }
 
-export interface RouteMeta {
-}
+export interface RouteMeta extends Record<string | number | symbol, any> {}

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -18,7 +18,9 @@ const Abc = { template: '<div>abc</div>' }
 const Async = () => Promise.resolve({ template: '<div>async</div>' })
 
 let err: any
-if (VueRouter.isNavigationFailure(err, VueRouter.NavigationFailureType.aborted)) {
+if (
+  VueRouter.isNavigationFailure(err, VueRouter.NavigationFailureType.aborted)
+) {
   err.from.fullPath.split('/')
 }
 
@@ -104,7 +106,7 @@ const router = new VueRouter({
             abc: Abc,
             asyncComponent: Async
           },
-          meta: { auth: true },
+          meta: { auth: true, nested: { foo: '' } },
           beforeEnter(to, from, next) {
             to.params
             from.params
@@ -229,7 +231,7 @@ const Components: (
   | AsyncComponent
 )[] = router.getMatchedComponents()
 
-const match: Route = router.match('/more');
+const match: Route = router.match('/more')
 
 const vm = new Vue({
   router,

--- a/types/test/meta.ts
+++ b/types/test/meta.ts
@@ -1,0 +1,45 @@
+import VueRouter from '../index'
+
+const component = { template: '<div>home</div>' }
+
+declare module '../index' {
+  export interface RouteMeta {
+    requiresAuth?: boolean
+    nested: { foo: string }
+  }
+}
+
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/',
+      component,
+      meta: {
+        requiresAuth: true,
+        // still allowed
+        other: true,
+        nested: {
+          foo: 'bar'
+        }
+      }
+    },
+    {
+      path: '/foo',
+      component,
+      // @ts-expect-error
+      meta: {}
+    }
+  ]
+})
+
+router.beforeEach(to => {
+  // should pass
+  if (to.meta!.requiresAuth === true) {
+  }
+  // still pass because any
+  if (to.meta!.lol === true) {
+  }
+  // @ts-expect-error: nested will never be true
+  if (to.meta!.nested === true) {
+  }
+})


### PR DESCRIPTION
Close #3183


I added a `RouteMeta` interface to the type declarations to allow for stronger type safety using [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).

For example:
```ts
declare module 'vue-router/types/router' {
    interface RouteMeta {
        x: string;
    }
}
```
Would define `myRoute.meta.x` to be a `string`. Non-existent properties will show an error.

Unfortunately this is a (minor) breaking change. As far as I know this can't be avoided without sacrificing the added type-safety.
Users can manually revert to the original "`any`" behavior using an augmentation like this:
```ts
declare module 'vue-router/types/router' {
    interface RouteMeta {
        [key: string]: any;
    }
}
```
I can't make this the default however, because it can't be _overwritten_ using module augmentation.
In other words: the "`any`"-index type would stay "active", thus defeating the purpose of added type-safety.

I hope this suggestion can be considered nonetheless.