### PR TITLE
fix(type): use any for Location.params

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -163,7 +163,7 @@ export interface Location {
   path?: string
   hash?: string
   query?: Dictionary<string | (string | null)[] | null | undefined>
-  params?: Dictionary<string>
+  params?: Dictionary<any>
   append?: boolean
   replace?: boolean
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
When passing props to route components, params are props, and props can be "any" type. For example:

in route config:
```js
const routes = [{
    name: 'a',
    path: '/a',
    props: true,
    component: A, // component A has a `aPropObject` prop 
}];
```

in component:
```js
this.$router.push({
    name: 'xxxx',
    params: {
        aPropObject: {}, // an object or anything else
    },
});
```