### PR TITLE
fix(util/query): prevent overriding prototype propery names using querystring

### DIFF
--- a/src/util/query.js
+++ b/src/util/query.js
@@ -58,10 +58,16 @@ function parseQuery (query: string): Dictionary<string> {
     return res
   }
 
+  const illegalNames = Object.getOwnPropertyNames(Object.getPrototypeOf(res))
+
   query.split('&').forEach(param => {
     const parts = param.replace(/\+/g, ' ').split('=')
     const key = decode(parts.shift())
     const val = parts.length > 0 ? decode(parts.join('=')) : null
+
+    if (illegalNames.includes(key)) {
+      return
+    }
 
     if (res[key] === undefined) {
       res[key] = val


### PR DESCRIPTION
Allowing prototype property names such as toString, \_\_proto__, ... to get override by querystrings with same names, leads to unknown behaviors.

Steps to reproduce the issue:

1. start the `dev` server.
2. go to the URL: http://localhost:8080/route-params/items/1/logs?toString

![image](https://user-images.githubusercontent.com/3686626/103210673-47e4c480-48fe-11eb-8a91-24f13705b826.png)