### PR TITLE
fix(warn): only warn if  "tag" or "event"  is used

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -132,14 +132,14 @@ export default {
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      if (this.tag && !warnedTagProp) {
+      if ('tag' in this.$options.propsData && !warnedTagProp) {
         warn(
           false,
           `<router-link>'s tag prop is deprecated and has been removed in Vue Router 4. Use the v-slot API to remove this warning: https://next.router.vuejs.org/guide/migration/#removal-of-event-and-tag-props-in-router-link.`
         )
         warnedTagProp = true
       }
-      if (this.event && !warnedEventProp) {
+      if ('event' in this.$options.propsData && !warnedEventProp) {
         warn(
           false,
           `<router-link>'s event prop is deprecated and has been removed in Vue Router 4. Use the v-slot API to remove this warning: https://next.router.vuejs.org/guide/migration/#removal-of-event-and-tag-props-in-router-link.`


### PR DESCRIPTION
closes #3457
Only show deprecation warning if the props "tag" or "event" are actually passed by the consumer (key exists in `$options.propsData`, figured this out by experimenting 😅), not if they have any value at all (they always have a value since a default is specified in the props definition)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
