### PR TITLE
docs(link): add `custom` prop to samples

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,6 +23,7 @@ sidebar: auto
 ```html
 <router-link
   to="/about"
+  custom
   v-slot="{ href, route, navigate, isActive, isExactActive }"
 >
   <NavLink :active="isActive" :href="href" @click="navigate"
@@ -45,6 +46,7 @@ Sometimes we may want the active class to be applied to an outer element rather 
 <router-link
   to="/foo"
   v-slot="{ href, route, navigate, isActive, isExactActive }"
+  custom
 >
   <li
     :class="[isActive && 'router-link-active', isExactActive && 'router-link-exact-active']"


### PR DESCRIPTION
The `tag` prop of `<router-link>` has been removed in v4.0.0+

https://github.com/vuejs/rfcs/blob/master/active-rfcs/0021-router-link-scoped-slot.md

The `custom` prop is functional, however it is not mentioned anywhere in the docs.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
