### PR TITLE
fix: replace existing route in addRoute show warning msg

### DIFF
--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -144,10 +144,8 @@ function addRouteRecord (
     })
   }
 
-  if (!pathMap[record.path]) {
-    pathList.push(record.path)
-    pathMap[record.path] = record
-  }
+  pathList.push(record.path)
+  pathMap[record.path] = record
 
   if (route.alias !== undefined) {
     const aliases = Array.isArray(route.alias) ? route.alias : [route.alias]
@@ -178,9 +176,8 @@ function addRouteRecord (
   }
 
   if (name) {
-    if (!nameMap[name]) {
-      nameMap[name] = record
-    } else if (process.env.NODE_ENV !== 'production' && !matchAs) {
+    nameMap[name] = record
+    if (!nameMap[name] && process.env.NODE_ENV !== 'production' && !matchAs) {
       warn(
         false,
         `Duplicate named routes definition: ` +

--- a/src/create-route-map.js
+++ b/src/create-route-map.js
@@ -144,7 +144,9 @@ function addRouteRecord (
     })
   }
 
-  pathList.push(record.path)
+  if (!pathMap[record.path]) {
+    pathList.push(record.path)
+  }
   pathMap[record.path] = record
 
   if (route.alias !== undefined) {


### PR DESCRIPTION
fix: addRoute is not work when there is already route with same name. replaced existing route in addRoute and show warning msg
