### PR TITLE
ci: update the chromedriver version to fix e2e test error in Circleci

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "babel-preset-flow-vue": "^1.0.0",
     "browserstack-local": "^1.4.8",
     "buble": "^0.19.8",
-    "chromedriver": "^86.0.0",
+    "chromedriver": "^90.0.0",
     "conventional-changelog-cli": "^2.0.11",
     "cross-spawn": "^7.0.3",
     "css-loader": "^2.1.1",


### PR DESCRIPTION
I found that cicleci has not run `yarn run test:e2e` normally for some time due to the low version of chromedriver.

Check the [cicleci log](https://app.circleci.com/pipelines/github/vuejs/vue-router/409/workflows/ab49dd9d-4a6c-41a7-a265-c954e1c94271/jobs/6801/parallel-runs/0/steps/0-102).