### PR TITLE
fix(types): added missing router.match

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -43,6 +43,7 @@ export declare class VueRouter {
   go(n: number): void
   back(): void
   forward(): void
+  match (raw: RawLocation, current?: Route, redirectedFrom?: Location): Route
   getMatchedComponents(to?: RawLocation | Route): Component[]
   onReady(cb: Function, errorCb?: ErrorHandler): void
   onError(cb: ErrorHandler): void

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -229,6 +229,8 @@ const Components: (
   | AsyncComponent
 )[] = router.getMatchedComponents()
 
+const match: Route = router.match('/more');
+
 const vm = new Vue({
   router,
   template: `


### PR DESCRIPTION
Fixed the missing definition of a `match` method in `VueRouter` class