### PR TITLE
docs: aria-current-value type `"true"` and `"false"`

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -188,7 +188,7 @@ If you add a `target="_blank"` to your `a` element, you must omit the `@click="n
 
 ### aria-current-value
 
-- type: `'page' | 'step' | 'location' | 'date' | 'time'`
+- type: `'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'`
 - default: `"page"`
 
   Configure the value of `aria-current` when the link is active with exact match. It must be one of the [allowed values for aria-current](https://www.w3.org/TR/wai-aria-1.2/#aria-current) in the ARIA spec. In most cases, the default of `page` should be the best fit.

--- a/docs/ja/api/README.md
+++ b/docs/ja/api/README.md
@@ -165,7 +165,7 @@ sidebar: auto
 
 ### aria-current-value
 
-- 型: `'page' | 'step' | 'location' | 'date' | 'time'`
+- 型: `'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'`
 - デフォルト: `"page"`
 
   完全一致によってリンクがアクティブになっているときに `aria-current` の値を設定します。ARIA spec において[aria-current で許可されている値](https://www.w3.org/TR/wai-aria-1.2/#aria-current)の1つでなければなりません。ほとんどの場合、デフォルト`page` が最適です。

--- a/docs/ru/api/README.md
+++ b/docs/ru/api/README.md
@@ -188,7 +188,7 @@ sidebar: auto
 
 ### aria-current-value
 
-- тип: `'page' | 'step' | 'location' | 'date' | 'time'`
+- тип: `'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'`
 - по умолчанию: `"page"`
 
   Настройка значения `aria-current` когда ссылка активна по точному (exact) совпадению. Это должно быть одно из [разрешённых значений для aria-current](https://www.w3.org/TR/wai-aria-1.2/#aria-current) спецификации ARIA. В большинстве случаев наиболее подходящим значением будет `page`.

--- a/docs/zh/api/README.md
+++ b/docs/zh/api/README.md
@@ -170,7 +170,7 @@ sidebar: auto
 
 ### aria-current-value
 
-- 类型: `'page' | 'step' | 'location' | 'date' | 'time'`
+- 类型: `'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'`
 - 默认值: `"page"`
 
   当链接根据精确匹配规则激活时配置的 `aria-current` 的值。这个值应该是 ARIA 规范中[允许的 aria-current 的值](https://www.w3.org/TR/wai-aria-1.2/#aria-current)。在绝大多数场景下，默认值 `page` 应该是最合适的。


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Since the type of https://router.vuejs.org/api/#aria-current-value is the same as the value that can be set for [`aria-current`](https://www.w3.org/TR/wai-aria-1.2/#aria-current) I thought that `"true"` and `"false"` should also be specified in the API documentation.

It would also be useful to make people aware that `aria-current-value="false"` can be overridden if `aria-current="page"` is unintentionally set.