### PR TITLE
Docs: Update Vue School banner

### DIFF
--- a/docs/.vuepress/theme/components/BannerTop.vue
+++ b/docs/.vuepress/theme/components/BannerTop.vue
@@ -11,10 +11,7 @@
         <img src="/images/vueschool/vs-backpack.png" alt="Backpack">
       </div>
       <div class="vs-slogan">
-        3-months Vue School for only $49 <span style="text-decoration: line-through">$75</span>!
-        <span class="vs-slogan-light">
-          Limited Time Offer
-        </span>
+        Less than <span class="vs-slogan-light">48 hours</span> left for the Vue School offer
       </div>
       <div class="vs-button">
         GET ACCESS
@@ -103,18 +100,23 @@ $contentClass = '.theme-default-content'
       color: #FFF
       font-weight: bold
       font-size: 14px
+      text-align: center
+      padding: 0 60px
       @media (min-width: 680px)
+        padding: 0
+        text-align: left
+        margin-right: 26px
+        margin-right: 0
         font-size: 18px
       > .vs-slogan-light
         color: #ff5338
-        display: block
         text-align: left
         @media (min-width: 900px)
           text-align: center
           display: inline
 
     .vs-button
-      margin-left: 43px
+      margin-left: 13px
       color: #FFF
       padding: 13px 24px
       border-radius: 40px


### PR DESCRIPTION
This PR changes the banner on top of router.vuejs.org to inform visitors that it's less than 48 hours before the summer sale expires.

Please merge this Monday, 2021-06-21.

[Click here to see the visuals of the banner](https://imgur.com/a/QBivUZl)

Related to [PR 3564](https://github.com/vuejs/vue-router/pull/3564)