### PR TITLE
Docs: Update Vue School Summer Sale banner

### DIFF
--- a/docs/.vuepress/theme/components/BannerTop.vue
+++ b/docs/.vuepress/theme/components/BannerTop.vue
@@ -11,7 +11,7 @@
         <img src="/images/vueschool/vs-backpack.png" alt="Backpack">
       </div>
       <div class="vs-slogan">
-        Less than <span class="vs-slogan-light">48 hours</span> left for the Vue School offer
+        Extended! <span class="vs-slogan-light">Last few hours</span> for the Vue School offer
       </div>
       <div class="vs-button">
         GET ACCESS
@@ -66,7 +66,7 @@ $contentClass = '.theme-default-content'
       height: 26px
     @media (min-width: 680px)
       display: block
-      left: 40px
+      left: 20px
       height: 40px
       img
         height: 40px
@@ -90,7 +90,7 @@ $contentClass = '.theme-default-content'
     .vs-backpack
       margin-right: 6px
       @media (min-width: 680px)
-        margin-right: 14px
+        margin-right: 2px
       img
         height: 50px
         @media (min-width: 680px)


### PR DESCRIPTION
This PR changes the banner on top of router.vuejs.org to inform visitors that it's only a few hours before the Summer Sale expires.

Please merge on **2021-06-24** around **5:00 pm CEST**.

[Click here to see the visuals of the banner.](https://imgur.com/a/KF8aQRZ)

Related to [PR 3564](https://github.com/vuejs/vue-router/pull/3564)