### PR TITLE
feat(scrollBehavior): Add container option

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -134,6 +134,18 @@ function isNumber (v: any): boolean {
   return typeof v === 'number'
 }
 
+function getOverflowedElement (overflowedElementSelector: any): any {
+  if (overflowedElementSelector) {
+    const overflowedElement = hashStartsWithNumberRE.test(overflowedElementSelector) // $flow-disable-line
+      ? document.getElementById(overflowedElementSelector.slice(1)) // $flow-disable-line
+      : document.querySelector(overflowedElementSelector)
+
+    return overflowedElement
+  }
+
+  return window
+}
+
 const hashStartsWithNumberRE = /^#\d/
 
 function scrollToPosition (shouldScroll, position) {
@@ -161,15 +173,18 @@ function scrollToPosition (shouldScroll, position) {
 
   if (position) {
     // $flow-disable-line
+
+    const overflowedElement = getOverflowedElement(shouldScroll.overflowedElementSelector)
+
     if ('scrollBehavior' in document.documentElement.style) {
-      window.scrollTo({
+      overflowedElement.scrollTo({
         left: position.x,
         top: position.y,
         // $flow-disable-line
         behavior: shouldScroll.behavior
       })
     } else {
-      window.scrollTo(position.x, position.y)
+      overflowedElement.scrollTo(position.x, position.y)
     }
   }
 }

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -135,15 +135,9 @@ function isNumber (v: any): boolean {
 }
 
 function getOverflowedElement (overflowedElementSelector: any): any {
-  if (overflowedElementSelector) {
-    const overflowedElement = hashStartsWithNumberRE.test(overflowedElementSelector) // $flow-disable-line
-      ? document.getElementById(overflowedElementSelector.slice(1)) // $flow-disable-line
-      : document.querySelector(overflowedElementSelector)
-
-    return overflowedElement
-  }
-
-  return window
+  return hashStartsWithNumberRE.test(overflowedElementSelector) // $flow-disable-line
+    ? document.getElementById(overflowedElementSelector.slice(1)) // $flow-disable-line
+    : document.querySelector(overflowedElementSelector)
 }
 
 const hashStartsWithNumberRE = /^#\d/
@@ -172,10 +166,12 @@ function scrollToPosition (shouldScroll, position) {
   }
 
   if (position) {
+    let overflowedElement = window
+    if (isObject && typeof shouldScroll.overflowedElementSelector === 'string') {
+      overflowedElement = getOverflowedElement(shouldScroll.overflowedElementSelector)
+    }
+
     // $flow-disable-line
-
-    const overflowedElement = getOverflowedElement(shouldScroll.overflowedElementSelector)
-
     if ('scrollBehavior' in document.documentElement.style) {
       overflowedElement.scrollTo({
         left: position.x,

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -134,13 +134,13 @@ function isNumber (v: any): boolean {
   return typeof v === 'number'
 }
 
-function getOverflowedElement (overflowedElementSelector: any): any {
-  return hashStartsWithNumberRE.test(overflowedElementSelector) // $flow-disable-line
-    ? document.getElementById(overflowedElementSelector.slice(1)) // $flow-disable-line
-    : document.querySelector(overflowedElementSelector)
-}
-
 const hashStartsWithNumberRE = /^#\d/
+
+function getContainerElement (containerSelector: any): any {
+  return hashStartsWithNumberRE.test(containerSelector) // $flow-disable-line
+    ? document.getElementById(containerSelector.slice(1)) // $flow-disable-line
+    : document.querySelector(containerSelector)
+}
 
 function scrollToPosition (shouldScroll, position) {
   const isObject = typeof shouldScroll === 'object'
@@ -166,21 +166,21 @@ function scrollToPosition (shouldScroll, position) {
   }
 
   if (position) {
-    let overflowedElement = window
-    if (isObject && typeof shouldScroll.overflowedElementSelector === 'string') {
-      overflowedElement = getOverflowedElement(shouldScroll.overflowedElementSelector)
+    let containerElement = window
+    if (isObject && typeof shouldScroll.container === 'string') {
+      containerElement = getContainerElement(shouldScroll.container)
     }
 
     // $flow-disable-line
     if ('scrollBehavior' in document.documentElement.style) {
-      overflowedElement.scrollTo({
+      containerElement.scrollTo({
         left: position.x,
         top: position.y,
         // $flow-disable-line
         behavior: shouldScroll.behavior
       })
     } else {
-      overflowedElement.scrollTo(position.x, position.y)
+      containerElement.scrollTo(position.x, position.y)
     }
   }
 }


### PR DESCRIPTION
Add the option "container" to scrollBehavior.
This will allow developers to specify the container element they want the scroll update to happen to.
It will default to window if not specified.
Normally you want to reset the scrollbar when users click a router link and move to a new route, but current system wont work if you have a container element with scrollbar instead of window.