### PR TITLE
docs: Added supported version to API docs for START_LOCATION

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -342,7 +342,7 @@ Since it's just a component, it works with `<transition>` and `<keep-alive>`. Wh
 
   The current route represented as a [Route Object](#the-route-object).
 
-### router.START_LOCATION
+### router.START_LOCATION (3.5.0+)
 
 - type: `Route`
 


### PR DESCRIPTION
I wanted to use START_LOCATION and was trying to figure out why I was not able to. Eventually figured out it was from version 3.5.0 but it was not indicated in the API docs.

This PR adds that version info to indicate that this property is available from v3.5.0+