### PR TITLE
Docs: Update Vue School BTS 21 banner

### DIFF
--- a/docs/.vuepress/theme/components/BannerTop.vue
+++ b/docs/.vuepress/theme/components/BannerTop.vue
@@ -1,5 +1,5 @@
 <template>
-  <a id="vs" href="https://vueschool.io/sales/summer-vue?friend=vuerouter" target="_blank" rel="noreferrer">
+  <a id="vs" href="https://vueschool.io/sales/back-to-school?friend=vuerouter" target="_blank" rel="noreferrer">
     <div class="vs-iso">
       <img src="/images/vueschool/vs-iso.svg" alt="Vue School Logo">
     </div>
@@ -11,10 +11,7 @@
         <img src="/images/vueschool/vs-backpack.png" alt="Backpack">
       </div>
       <div class="vs-slogan">
-        3-months Vue School for only $49 <span style="text-decoration: line-through; opacity: 0.5;">$75</span>!
-        <span class="vs-slogan-light">
-          Limited Time Offer
-        </span>
+        Less than <span class="vs-slogan-light">48 hours</span> left for the Vue School offer
       </div>
       <div class="vs-button">
         GET ACCESS


### PR DESCRIPTION
This PR changes the banner on top of router.vuejs.org to inform visitors that it's less than 48 hours before the BTS sale expires.

Please merge this Monday, 2021-10-04.

![Screenshot 2021-10-04 at 09-51-09 Vue Router](https://user-images.githubusercontent.com/3766839/135855419-d37c2f1e-4f15-4bab-ad7f-ba174bbdfb7d.png)


