### PR TITLE
Docs: Remove Vue School BTS 21 banner

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="main-container" :class="{ 'has-top-banner': showTopBanner }">
-    <BannerTop v-if="showTopBanner" @close="closeBannerTop" />
+  <div class="main-container">
     <ParentLayout>
       <template #page-top>
         <CarbonAds
@@ -65,22 +64,11 @@ export default {
   components: {
     ParentLayout,
     CarbonAds,
-    BuySellAds,
-    BannerTop: () => import('./components/BannerTop.vue')
+    BuySellAds
   },
   data() {
     return {
-      sponsors,
-      showTopBanner: false
-    }
-  },
-  mounted() {
-    this.showTopBanner = !localStorage.getItem('VS_BTS_BANNER_CLOSED')
-  },
-  methods: {
-    closeBannerTop() {
-      this.showTopBanner = false
-      localStorage.setItem('VS_BTS_BANNER_CLOSED', 1)
+      sponsors
     }
   }
 }


### PR DESCRIPTION
This PR removes the Vue School BTS banner from the top of router.vuejs.org.

The landing page will keep working after the promo ends, so the link (https://vueschool.io/sales/back-to-school?friend=vuerouter) will still be valid.