### PR TITLE
fix: clean more than two consecutive slashes

### DIFF
--- a/src/util/path.js
+++ b/src/util/path.js
@@ -70,5 +70,5 @@ export function parsePath (path: string): {
 }
 
 export function cleanPath (path: string): string {
-  return path.replace(/\/\//g, '/')
+  return path.replace(/\/+/g, '/')
 }


### PR DESCRIPTION
**Issue**:
Currently a path beginning with three slashes (`///`) will in fact potentially redirect to another domain. This is because the `cleanPath` utility only replaces two slashes, leaving two behind.

**Reproduction**:
https://stackblitz.com/edit/vue-router-3-redirect

This PR simply replaces consecutive slashes with a single slash.