### PR TITLE
Docs: Remove Vue School's Black Friday banner

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -1,12 +1,5 @@
 <template>
-  <div
-    class="main-container"
-    :class="{ 'has-top-banner': showTopBanner }"
-  >
-    <BannerTop
-      v-if="showTopBanner"
-      @close="closeBannerTop"
-    />
+  <div class="main-container">
     <ParentLayout>
       <template #page-top>
         <CarbonAds
@@ -71,22 +64,11 @@ export default {
   components: {
     ParentLayout,
     CarbonAds,
-    BuySellAds,
-    BannerTop: () => import('./components/VueSchool/BannerTop.vue')
+    BuySellAds
   },
   data() {
     return {
-      sponsors,
-      showTopBanner: false
-    }
-  },
-  mounted () {
-    this.showTopBanner = !localStorage.getItem('VS_BF21_BANNER_CLOSED')
-  },
-  methods: {
-    closeBannerTop () {
-      this.showTopBanner = false
-      localStorage.setItem('VS_BF21_BANNER_CLOSED', 1)
+      sponsors
     }
   }
 }


### PR DESCRIPTION
This PR removes the Vue School Black Friday banner introduced in https://github.com/vuejs/vue-router/pull/3664

Please merge this **Friday Dec 10th**.

The landing page will keep working after the promo ends, so the link (https://vueschool.io/sales/blackfriday?friend=vuerouter) will still be valid.