### PR TITLE
fix(install): adjust this.$options.router judgment

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -20,7 +20,7 @@ export function install (Vue) {
 
   Vue.mixin({
     beforeCreate () {
-      if (isDef(this.$options.router)) {
+      if (this.$options.router) {
         this._routerRoot = this
         this._router = this.$options.router
         this._router.init(this)


### PR DESCRIPTION
The judgment "isDef(this.$options.router)" can be more rigorous.
Since in some cases, the router can be null, which will cause the execute error.
And We have faced this situation in  [@testing-library/vue/render.js](https://github.com/testing-library/vue-testing-library/blob/main/src/render.js) 
BTW, this change have been seen in the vue-router-next.