### PR TITLE
test: Set NODE_ENV before error handling tests.

### DIFF
--- a/test/unit/specs/error-handling.spec.js
+++ b/test/unit/specs/error-handling.spec.js
@@ -5,6 +5,10 @@ import { NavigationFailureType } from '../../../src/util/errors'
 Vue.use(VueRouter)
 
 describe('error handling', () => {
+  beforeEach(function () {
+    process.env.NODE_ENV = 'development'
+  })
+
   it('onReady errors', done => {
     const router = new VueRouter()
     const err = new Error('foo')


### PR DESCRIPTION
Error handling tests fail depending on other tests ordering, because `process.env.NODE_ENV` can be `production` and this test file don't set `NODE_ENV`.

Fix #3712.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
