### PR TITLE
Show Vue School logo in free weekend banner mobile

### DIFF
--- a/docs/.vuepress/theme/components/VueSchool/BannerTop.vue
+++ b/docs/.vuepress/theme/components/VueSchool/BannerTop.vue
@@ -64,6 +64,12 @@
   top: 20px;
 }
 
+#vs .vs-logo .logo-small {
+  width: 30px;
+  margin-left: -5px;
+  margin-top: 5px;
+}
+
 #vs .vs-logo .logo-big {
   display: none;
 }


### PR DESCRIPTION
This PR updates the free weekend banner to include the logo in the mobile viewport.

[Screenshot](https://imgur.com/a/6DnCDWr)

Related to https://github.com/vuejs/vue-router/pull/3737
