### PR TITLE
Update Vue School banner copy

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -91,7 +91,9 @@ export default {
     }
   },
   mounted () {
-    this.showTopBanner = !localStorage.getItem('VS_FW_22_BANNER_CLOSED')
+    const now = new Date()
+    const end = new Date('2022-05-04T00:00:00+02:00')
+    this.showTopBanner = !localStorage.getItem('VS_FW_22_BANNER_CLOSED') && (now < end)
   },
   methods: {
     closeBannerTop () {

--- a/docs/.vuepress/theme/components/VueSchool/BannerTop.vue
+++ b/docs/.vuepress/theme/components/VueSchool/BannerTop.vue
@@ -12,10 +12,10 @@
     <div class="vs-core">
       <div class="vs-slogan">
         <div class="vs-slogan-title">
-          Get up to <strong>40% off</strong> your Vue School Subscription
+          Extended for <strong>48 hours!</strong>
         </div>
         <div class="vs-slogan-subtitle">
-          Time Limited Offer
+          Get up to 40% off your Vue School Subscription
         </div>
       </div>
       <div class="vs-button">


### PR DESCRIPTION
This PR updates the text of the Vue School top banner to announce the promo is extended for 48 hs.

Please merge this on `2022-05-01T00:00:00+02:00` (so, on the first minute of Sunday, or soon later).

The banner will stop appearing automatically on `2022-05-04T00:00:00+02:00`, the date is hard-coded.

[Click here to see screenshots of the banner](https://imgur.com/a/zuGyilC)