### PR TITLE
docs: fix href to v3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Vue Router is part of the Vue Ecosystem and is an MIT-licensed open source proje
 
 ---
 
-Get started with the [documentation](http://router.vuejs.org), or play with the [examples](https://github.com/vuejs/vue-router/tree/dev/examples) (see how to run them below).
+Get started with the [documentation](http://v3.router.vuejs.org), or play with the [examples](https://github.com/vuejs/vue-router/tree/dev/examples) (see how to run them below).
 
 ### Development Setup
 


### PR DESCRIPTION
misdirect me once, blame on me. misdirect me twice, submit a PR.

head of readme on v3 router references the v4 router landingpage.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
