### PR TITLE
fix: onBeforeRouteLeave not remove (fix #3826)

### DIFF
--- a/src/composables/guards.js
+++ b/src/composables/guards.js
@@ -35,9 +35,9 @@ export function onBeforeRouteLeave (guard) {
 }
 
 function registerGuard (router, guard, fn, depth) {
-  return router.beforeEach((to, from, next) => {
-    return fn(to, from, depth) ? guard(to, from, next) : next()
-  })
+  return router.beforeEach((to, from, next) =>
+    fn(to, from, depth) ? guard(to, from, next) : next()
+  )
 }
 
 const noop = () => {}
@@ -70,7 +70,7 @@ function useFilteredGuard (guard, fn) {
     })
     onDeactivated(() => {
       removeGuard()
-      removeGuard = null // reset removeGuard
+      removeGuard = null
     })
 
     return removeGuard

--- a/src/composables/guards.js
+++ b/src/composables/guards.js
@@ -34,6 +34,12 @@ export function onBeforeRouteLeave (guard) {
   return useFilteredGuard(guard, isLeaveNavigation)
 }
 
+function registerGuard (router, guard, fn, depth) {
+  return router.beforeEach((to, from, next) => {
+    return fn(to, from, depth) ? guard(to, from, next) : next()
+  })
+}
+
 const noop = () => {}
 function useFilteredGuard (guard, fn) {
   const instance = getCurrentInstance()
@@ -56,17 +62,11 @@ function useFilteredGuard (guard, fn) {
       : null
 
   if (depth != null) {
-    const registerGuard = () => {
-      return router.beforeEach((to, from, next) => {
-        return fn(to, from, depth) ? guard(to, from, next) : next()
-      })
-    }
-
-    let removeGuard = registerGuard()
+    let removeGuard = registerGuard(router, guard, fn, depth)
     onUnmounted(removeGuard)
 
     onActivated(() => {
-      removeGuard = removeGuard || registerGuard()
+      removeGuard = removeGuard || registerGuard(router, guard, fn, depth)
     })
     onDeactivated(() => {
       removeGuard()


### PR DESCRIPTION
The problem seems to be that `onBeforeRouteLeave` lacks handling of `onActivated` and `onDeactivated` hooks in the keep-alive component.

I referred to vue router 4 to fix the processing of `onBeforeRouteLeave`.

https://github.com/vuejs/router/blob/main/packages/router/src/navigationGuards.ts

Fix #3826