### PR TITLE
correct typedef of Route

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -411,7 +411,7 @@ export interface Route {
   path: string
   name?: string | null
   hash: string
-  query: Dictionary<string | (string | null)[]>
+  query: Dictionary<string | null | (string | null)[]>
   params: Dictionary<string>
   fullPath: string
   matched: RouteRecord[]

--- a/types/test/route-query.spec.ts
+++ b/types/test/route-query.spec.ts
@@ -1,0 +1,103 @@
+import VueRouter from '../index'
+import { Route } from '../index'
+
+const component = { template: '<div>test</div>' }
+
+const router = new VueRouter({
+  routes: [
+    { path: '/:id', component }
+  ]
+})
+
+describe('Route query types', () => {
+  it('should handle string query parameter', () => {
+    const route: Route = {
+      path: '/test',
+      query: { foo: 'bar' },
+      params: {},
+      fullPath: '/test?foo=bar',
+      name: null,
+      hash: '',
+      matched: [],
+      redirectedFrom: undefined,
+      meta: {}
+    }
+    
+    expect(typeof route.query.foo).toBe('string')
+  })
+
+  it('should handle null query parameter', () => {
+    const route: Route = {
+      path: '/test',
+      query: { foo: null },
+      params: {},
+      fullPath: '/test?foo',
+      name: null,
+      hash: '',
+      matched: [],
+      redirectedFrom: undefined,
+      meta: {}
+    }
+    
+    expect(route.query.foo).toBeNull()
+  })
+
+  it('should handle array of strings query parameter', () => {
+    const route: Route = {
+      path: '/test',
+      query: { foo: ['bar', 'baz'] },
+      params: {},
+      fullPath: '/test?foo=bar&foo=baz',
+      name: null,
+      hash: '',
+      matched: [],
+      redirectedFrom: undefined,
+      meta: {}
+    }
+    
+    expect(Array.isArray(route.query.foo)).toBe(true)
+    expect(route.query.foo).toEqual(['bar', 'baz'])
+  })
+
+  it('should handle array with null query parameter', () => {
+    const route: Route = {
+      path: '/test',
+      query: { foo: ['bar', null] },
+      params: {},
+      fullPath: '/test?foo=bar&foo',
+      name: null,
+      hash: '',
+      matched: [],
+      redirectedFrom: undefined,
+      meta: {}
+    }
+    
+    expect(Array.isArray(route.query.foo)).toBe(true)
+    expect(route.query.foo).toEqual(['bar', null])
+  })
+
+  it('should handle mixed query parameters', () => {
+    const route: Route = {
+      path: '/test',
+      query: { 
+        string: 'value',
+        nullValue: null,
+        stringArray: ['one', 'two'],
+        mixedArray: ['three', null]
+      },
+      params: {},
+      fullPath: '/test?string=value&nullValue&stringArray=one&stringArray=two&mixedArray=three&mixedArray',
+      name: null,
+      hash: '',
+      matched: [],
+      redirectedFrom: undefined,
+      meta: {}
+    }
+    
+    expect(typeof route.query.string).toBe('string')
+    expect(route.query.nullValue).toBeNull()
+    expect(Array.isArray(route.query.stringArray)).toBe(true)
+    expect(Array.isArray(route.query.mixedArray)).toBe(true)
+    expect(route.query.mixedArray).toEqual(['three', null])
+  })
+})


### PR DESCRIPTION
Fixes #3566 

updated typedef of interface Route from `query: Dictionary<string | (string | null)[]>` to `query: Dictionary<string | null | (string | null)[]>`