### PR TITLE
fix: Versions in docs (fix #1532)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -85,8 +85,9 @@ module.exports = ctx => ({
     smoothScroll: true,
     locales: {
       '/': {
-        label: 'English',
+        label: 'English (Up to v2.6)',
         selectText: 'Languages',
+        version: '2.6',
         editLinkText: 'Edit this page on GitHub',
         nav: [
           {
@@ -139,8 +140,9 @@ module.exports = ctx => ({
         ]
       },
       '/zh/': {
-        label: '简体中文',
+        label: '简体中文 (Up to v2.3)',
         selectText: '选择语言',
+        version: '2.3',
         editLinkText: '在 GitHub 上编辑此页',
         nav: [
           {
@@ -193,8 +195,9 @@ module.exports = ctx => ({
         ]
       },
       '/ja/': {
-        label: '日本語',
+        label: '日本語 (Up to v2.4)',
         selectText: '言語',
+        version: '2.4',
         editLinkText: 'GitHub 上でこのページを編集する',
         nav: [
           {
@@ -247,8 +250,9 @@ module.exports = ctx => ({
         ]
       },
       '/ru/': {
-        label: 'Русский',
+        label: 'Русский (Up to v2.1)',
         selectText: 'Переводы',
+        version: '2.1',
         editLinkText: 'Изменить эту страницу на GitHub',
         nav: [
           {
@@ -301,8 +305,9 @@ module.exports = ctx => ({
         ]
       },
       '/kr/': {
-        label: '한국어',
+        label: '한국어 (Up to v2.0)',
         selectText: '언어',
+        version: '2.0',
         editLinkText: 'GitHub에서 이 문서를 수정하세요',
         nav: [
           {
@@ -354,8 +359,9 @@ module.exports = ctx => ({
         ]
       },
       '/fr/': {
-        label: 'Français',
+        label: 'Français (Up to v2.5)',
         selectText: 'Langues',
+        version: '2.5',
         editLinkText: 'Editer cette page sur Github',
         nav: [
           {

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,10 @@ actionLink: /installation.html
 footer: MIT Licensed | Copyright © 2014-present Evan You, Eduardo San Martin Morote
 ---
 
+::: tip VERSION NOTE
+This documentation is up to date with Vue Router v2.6
+:::
+
 Vue Router is the official router for [Vue.js](http://vuejs.org). It deeply integrates with Vue.js core to make building Single Page Applications with Vue.js a breeze. Features include:
 
 - Nested route/view mapping

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -6,6 +6,10 @@ actionLink: /fr/installation.html
 footer: MIT Licensed | Copyright © 2014-present Evan You, Eduardo San Martin Morote
 ---
 
+::: tip NOTE DE VERSION
+Cette documentation est à jour avec Vue Router v2.5
+:::
+
 Vue Router est le router officiel pour [Vue.js](http://vuejs.org). Il s'intègre aisément avec Vue.js pour faire des applications mono page avec Vue.js. Fonctionnalités incluses:
 
 - Vues et routes imbriquées

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -8,6 +8,10 @@ footer: MIT Licensed | Copyright © 2014-present Evan You, Eduardo San Martin Mo
 
 <div class="vueschool"><a href="https://vueschool.io/courses/vue-router-for-everyone?friend=vuerouter" target="_blank" rel="sponsored noopener" title="Learn how to build powerful Single Page Applications with the Vue Router on Vue School">Watch a free video course about Vue Router on Vue School</a></div>
 
+::: tip バージョン情報
+このドキュメントは Vue Router v2.4 に対応しています
+:::
+
 Vue Router は [Vue.js](http://vuejs.org) 公式ルータです。これは Vue.js のコアと深く深く統合されており、Vue.js でシングルページアプリケーションを構築します。機能は次の通りです:
 
 - ネストされたルート/ビューマッピング

--- a/docs/kr/README.md
+++ b/docs/kr/README.md
@@ -6,6 +6,10 @@ actionLink: /kr/installation.html
 footer: MIT Licensed | Copyright © 2014-present Evan You, Eduardo San Martin Morote
 ---
 
+::: tip 버전 정보
+이 문서는 Vue Router v2.0까지 반영되어 있습니다
+:::
+
 Vue 라우터는 [Vue.js](http://vuejs.org)의 공식 라우터입니다.
 Vue.js를 사용한 싱글 페이지 앱을 쉽게 만들 수 있도록 Vue.js의 코어와 긴밀히 통합되어 있습니다.
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -6,6 +6,10 @@ actionLink: /ru/installation.html
 footer: MIT Licensed | Copyright © 2014-present Evan You, Eduardo San Martin Morote
 ---
 
+::: tip ИНФОРМАЦИЯ О ВЕРСИИ
+Эта документация обновлена для Vue Router v2.1
+:::
+
 Vue Router — официальная библиотека маршрутизации для [Vue.js](https://ru.vuejs.org/). Она глубоко интегрируется с Vue.js и позволяет легко создавать SPA-приложения. Включает следующие возможности:
 
 - Вложенные маршруты/представления

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -8,6 +8,10 @@ footer: MIT Licensed | Copyright © 2014-present Evan You, Eduardo San Martin Mo
 
 <div class="vueschool"><a href="https://vueschool.io/courses/vue-router-for-everyone?friend=vuerouter" target="_blank" rel="sponsored noopener" title="Learn how to build powerful Single Page Applications with the Vue Router on Vue School">观看 Vue School 的关于 Vue Router 的免费视频课程 (英文)</a></div>
 
+::: tip 版本说明
+此文档更新至 Vue Router v2.3
+:::
+
 Vue Router 是 [Vue.js](http://cn.vuejs.org) 官方的路由管理器。它和 Vue.js 的核心深度集成，让构建单页面应用变得易如反掌。包含的功能有：
 
 - 嵌套的路由/视图表


### PR DESCRIPTION


```
Title: fix: Versions in docs (fix #1532)

Description:

This PR adds version information to the Vue Router documentation to help users understand which version of the documentation is available in their preferred language. This addresses issue #1532 where users had no way of knowing if their language's documentation was up to date with the latest features.

Changes made:
- Updated config.js to include version information in language labels
- Added version tracking fields for each language
- Added version information tips to each language's README.md:
  - English (Up to v2.6)
  - French (Up to v2.5)
  - Japanese (Up to v2.4)
  - Chinese (Up to v2.3)
  - Russian (Up to v2.1)
  - Korean (Up to v2.0)

This helps users by:
- Clearly showing which version each translation covers
- Making it easy to see if a specific feature is documented in their language
- Helping users decide whether to use English docs for newer features

Implementation:
- Added version information to language selector in the navigation
- Added prominent version notices at the top of each language's main documentation
- Maintained consistent formatting across all languages
- Preserved all existing documentation content and structure

Testing:
- Verified version information appears correctly in language selector
- Confirmed version tips display properly in all language versions
- Checked formatting and layout consistency across all pages

This implements the solution proposed in the original issue while maintaining the documentation's clean and professional appearance.
```