### PR TITLE
fix(types): add null to Route.query type definition

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -411,7 +411,7 @@ export interface Route {
   path: string
   name?: string | null
   hash: string
-  query: Dictionary<string | (string | null)[]>
+  query: Dictionary<string | null | (string | null)[]>
   params: Dictionary<string>
   fullPath: string
   matched: RouteRecord[]


### PR DESCRIPTION
## Summary
- Fixes #3566 - The type definition of Route.query was missing `null` as a valid type
- When parsing URLs like `/path?foo#bar` where a query parameter has no value, the parser correctly returns `null` for that parameter value
- This fix updates the Route interface to properly reflect this behavior

## Technical Details
The query parsing code in `src/util/query.js` (line 64) sets `null` for parameters without values:
```javascript
const val = parts.length > 0 ? decode(parts.join('=')) : null
```

The type definition was:
```typescript
query: Dictionary<string | (string | null)[]>
```

But should be:
```typescript
query: Dictionary<string | null | (string | null)[]>
```

## Test Plan
- [x] Verified eslint passes
- [x] Verified TypeScript type tests pass (`npm run test:types`)
- [x] Verified unit tests pass (115 specs, 0 failures)

## AI Transparency
This PR was created with AI assistance (Claude claude-opus-4-5). The fix was identified and implemented by analyzing the issue description and the source code to understand the correct type for query parameter values.

Co-Authored-By: Claude (claude-opus-4-5) <noreply@anthropic.com>