### PR TITLE
fix(util): resolvePath returns empty string when navigating above root

### DIFF
--- a/src/util/path.js
+++ b/src/util/path.js
@@ -39,7 +39,7 @@ export function resolvePath (
     stack.unshift('')
   }
 
-  return stack.join('/')
+  return stack.join('/') || '/'
 }
 
 export function parsePath (path: string): {

--- a/test/unit/specs/path.spec.js
+++ b/test/unit/specs/path.spec.js
@@ -36,6 +36,12 @@ describe('Path utils', () => {
       const path = resolvePath('#hi', '/a/b')
       expect(path).toBe('/a/b#hi')
     })
+
+    it('relative parent at or beyond root stays at root', () => {
+      expect(resolvePath('..', '/')).toBe('/')
+      expect(resolvePath('..', '/a')).toBe('/')
+      expect(resolvePath('../..', '/a/b')).toBe('/')
+    })
   })
 
   describe('parsePath', () => {


### PR DESCRIPTION
## Bug

`resolvePath` in `src/util/path.js` returns an empty string `''` when a relative path resolves to or above the root.

**Reproduction:**
```js
resolvePath('..', '/')   // returns '' instead of '/'
resolvePath('..', '/a')  // returns '' instead of '/'
```

**Root cause:** When `..` segments pop all entries off the internal stack, `stack.join('/')` on a single-element `['']\ array produces `''`. The correct result per POSIX semantics (and common sense) is `'/'` — navigating above root should clamp to root.

## Fix

One-character change in `src/util/path.js`:

```diff
-  return stack.join('/')
+  return stack.join('/') || '/'
```

This has no effect on any path that correctly resolves to a non-empty string.

## Verification

```
npm run test:unit
# 116 specs, 0 failures
```

Three new assertions added in `test/unit/specs/path.spec.js` — all red before the fix, all green after.

> AI-assisted: this PR was prepared with the help of an AI coding assistant.
